### PR TITLE
Add CI workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Action to run `npm run lint` and `npm test` on pushes to `main` and all pull requests

## Testing
- `npm ci` *(fails: unable to reach registry)*
- `npm test` *(fails: vitest not found because dependencies couldn't be installed)*

------
https://chatgpt.com/codex/tasks/task_b_68584419c620832f84c21b432300be61