### PR TITLE
Fix GH pages action artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 


### PR DESCRIPTION
## Summary
- revert previous codex changes
- update the Upload Pages Artifact action to use a non-deprecated version

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars)*
- `npm test`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_68584891e0e4832fb4c4f8088a12c544