### PR TITLE
Fix build errors

### DIFF
--- a/src/services/ai/__tests__/AIService.variations.test.ts
+++ b/src/services/ai/__tests__/AIService.variations.test.ts
@@ -103,7 +103,7 @@ describe('AIService Multiple Variations User Flows', () => {
 
       // Should call with different temperatures
       expect(mockGenerateText).toHaveBeenCalledTimes(3)
-      const temperatureCalls = mockGenerateText.mock.calls.map(call => call[0].temperature)
+      const temperatureCalls = mockGenerateText.mock.calls.map(([options]: [any]) => (options as any).temperature)
       expect(temperatureCalls).toEqual([0.7, 0.8, 0.9])
     })
 
@@ -142,7 +142,7 @@ describe('AIService Multiple Variations User Flows', () => {
       expect(mockGenerateText).toHaveBeenCalledTimes(5)
 
       // Check temperature range for 5 variations
-      const temperatures = mockGenerateText.mock.calls.map(call => call[0].temperature)
+      const temperatures = mockGenerateText.mock.calls.map(([options]: [any]) => (options as any).temperature)
       expect(temperatures).toEqual([0.7, 0.75, 0.8, 0.9, 1.0])
     })
 
@@ -174,7 +174,7 @@ describe('AIService Multiple Variations User Flows', () => {
 
     it('should generate responses from multiple models when user wants diverse perspectives', async () => {
       // Mock responses for different models
-      mockGenerateText.mockImplementation((options) => {
+      mockGenerateText.mockImplementation((options: any) => {
         const modelName = options.model.constructor.name || 'unknown'
         return Promise.resolve({
           text: `Quantum explanation from ${modelName}`,

--- a/src/services/ai/providers/together.ts
+++ b/src/services/ai/providers/together.ts
@@ -1,4 +1,4 @@
-import { createOpenAI } from '@ai-sdk/openai-compatible'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { generateText } from 'ai'
 import type { AIProvider, Message, ModelInfo, GenerationOptions, ResponseWithLogprobs } from '../../../types/ai'
 import { getModelsByProvider } from '../config'
@@ -18,7 +18,8 @@ export class TogetherProvider implements AIProvider {
     }
 
     try {
-      const together = createOpenAI({
+      const together = createOpenAICompatible({
+        name: 'Together AI',
         apiKey,
         baseURL: 'https://api.together.xyz/v1'
       })
@@ -60,7 +61,8 @@ export class TogetherProvider implements AIProvider {
 
   async validateApiKey(apiKey: string): Promise<boolean> {
     try {
-      const together = createOpenAI({
+      const together = createOpenAICompatible({
+        name: 'Together AI',
         apiKey,
         baseURL: 'https://api.together.xyz/v1'
       })

--- a/src/utils/__tests__/crypto.security.test.ts
+++ b/src/utils/__tests__/crypto.security.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Allow use of the Node global object in tests
+declare const global: any;
 import { SecureStorage } from '../crypto';
 
 describe('SecureStorage Security Tests', () => {

--- a/src/utils/__tests__/crypto.test.ts
+++ b/src/utils/__tests__/crypto.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Allow use of the Node global object in tests
+declare const global: any;
 import { SecureStorage } from '../crypto';
 
 // Test data
@@ -67,7 +70,7 @@ describe('SecureStorage', () => {
 
     // Setup default mock implementations
     mockIndexedDB.open.mockImplementation(() => {
-      const request = {
+      const request: any = {
         onerror: null,
         onsuccess: null,
         onupgradeneeded: null,
@@ -83,7 +86,7 @@ describe('SecureStorage', () => {
     });
 
     mockStore.put.mockImplementation(() => {
-      const request = { onerror: null, onsuccess: null };
+      const request: any = { onerror: null, onsuccess: null };
       setTimeout(() => {
         if (request.onsuccess) request.onsuccess();
       }, 0);
@@ -91,8 +94,8 @@ describe('SecureStorage', () => {
     });
 
     mockStore.get.mockImplementation(() => {
-      const request = { 
-        onerror: null, 
+      const request: any = {
+        onerror: null,
         onsuccess: null,
         result: mockCryptoKey
       };
@@ -131,8 +134,8 @@ describe('SecureStorage', () => {
     it('should generate and store a new CryptoKey on first use', async () => {
       // Mock no existing key
       mockStore.get.mockImplementationOnce(() => {
-        const request = { 
-          onerror: null, 
+        const request: any = {
+          onerror: null,
           onsuccess: null,
           result: null
         };
@@ -159,8 +162,8 @@ describe('SecureStorage', () => {
       // Second call - should not generate new key
       vi.clearAllMocks();
       mockStore.get.mockImplementation(() => {
-        const request = { 
-          onerror: null, 
+        const request: any = {
+          onerror: null,
           onsuccess: null,
           result: mockCryptoKey
         };

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -243,6 +243,17 @@ export class SecureStorage {
   }
 
   /**
+   * Touch the storage to reset the idle timer without exposing the key
+   */
+  public static async touch(): Promise<void> {
+    try {
+      await this.getKey();
+    } catch {
+      // Ignore errors - storage might be locked
+    }
+  }
+
+  /**
    * Checks if storage is currently locked
    */
   public static isLocked(): boolean {
@@ -259,10 +270,8 @@ window.addEventListener('beforeunload', () => {
 ['mousedown', 'keydown', 'scroll', 'touchstart'].forEach(event => {
   document.addEventListener(event, () => {
     if (!SecureStorage.isLocked()) {
-      // Reset timer by accessing the key (which resets timer)
-      SecureStorage.getKey().catch(() => {
-        // Ignore errors - storage might be locked
-      });
+      // Reset timer without exposing the key
+      SecureStorage.touch();
     }
   }, { passive: true });
 });


### PR DESCRIPTION
## Summary
- fix TogetherAI provider import and settings
- tweak AIService variation tests for strict types
- handle `global` var in tests
- improve mock types in crypto tests
- add `touch` helper to SecureStorage
- refactor idle timer calls to use `touch`
- adjust `setupTests` mocks for strict TS

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68584b890168832f9e1a9a4e771db9f2