### PR TITLE
Improve mobile UI and possibility handling

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -67,7 +67,16 @@ const Message: React.FC<ExtendedMessageProps> = ({
             isUser
               ? 'bg-[#2a2a3a] border-[#3a3a4a]'
               : 'bg-[#1a1a1a] border-[#2a2a2a]'
+          } ${
+            message.isPossibility
+              ? 'border-dashed border-[#444] cursor-pointer hover:border-[#667eea]'
+              : ''
           }`}
+          onClick={() => {
+            if (message.isPossibility) {
+              onSelectPossibility?.(message)
+            }
+          }}
         >
           {/* Model Info for AI messages */}
           {!isUser &&

--- a/app/components/MessageWithIndependentPossibilities.tsx
+++ b/app/components/MessageWithIndependentPossibilities.tsx
@@ -55,23 +55,8 @@ const MessageWithIndependentPossibilities: React.FC<
   }
 
   // Convert Message selection callback to handle VirtualizedPossibilitiesPanel response format
-  const handleSelectResponse = (response: any) => {
-    // Convert PossibilityResponse back to Message format for compatibility
-    const messageResponse: Message = {
-      id: response.id,
-      role: 'assistant',
-      content: response.content,
-      model:
-        typeof response.model === 'string'
-          ? response.model
-          : response.model?.id,
-      temperature: response.temperature,
-      probability: response.probability,
-      timestamp: response.timestamp || new Date(),
-      systemInstruction:
-        response.systemInstruction?.name || response.systemInstruction,
-      isPossibility: true,
-    }
+  const handleSelectResponse = (response: Message) => {
+    const messageResponse = { ...response, isPossibility: true }
 
     // Find the last user message from the conversation to pass as the first parameter
     const lastUserMessage = conversationMessages

--- a/app/components/OptionCard.tsx
+++ b/app/components/OptionCard.tsx
@@ -51,7 +51,9 @@ const OptionCard: React.FC<OptionCardProps> = ({ response, onSelect }) => {
       "
       onClick={handleClick}
     >
-      <div className="grid grid-cols-[24px_1fr_140px_auto] gap-3 items-start">
+      <div
+        className="grid grid-cols-[24px_1fr_auto] md:grid-cols-[24px_1fr_140px_auto] gap-3 items-start"
+      >
         {/* Provider Logo */}
         <div className="w-6 h-6 rounded-md flex items-center justify-center flex-shrink-0 bg-white p-1 overflow-hidden mt-0.5">
           {getModelIcon()}
@@ -59,7 +61,7 @@ const OptionCard: React.FC<OptionCardProps> = ({ response, onSelect }) => {
 
         {/* Content Text */}
         <div className="text-sm leading-[1.5] text-[#e0e0e0] overflow-hidden">
-          <div className="break-words max-h-[2.8em] overflow-hidden">
+          <div className="break-words md:max-h-[2.8em] overflow-hidden">
             {response.content.length > 120
               ? response.content.slice(0, 120) + '...'
               : response.content}
@@ -70,12 +72,15 @@ const OptionCard: React.FC<OptionCardProps> = ({ response, onSelect }) => {
         </div>
 
         {/* Model Name */}
-        <div className="text-xs text-[#888] font-medium flex-shrink-0 mt-0.5">
+        <div className="text-xs text-[#888] font-medium flex-shrink-0 mt-0.5 hidden md:block">
           {getDisplayModelName(response.model.name)}
         </div>
 
         {/* Tags (Temperature, System Instructions, Probability) */}
         <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="md:hidden text-xs text-[#888] font-medium">
+            {getDisplayModelName(response.model.name)}
+          </span>
           {response.temperature !== undefined && (
             <div
               className="bg-[#2a2a3a] px-2 py-1 rounded text-[#ffa726] font-bold text-xs"

--- a/app/components/VirtualizedPossibilitiesPanel.tsx
+++ b/app/components/VirtualizedPossibilitiesPanel.tsx
@@ -3,15 +3,14 @@ import { useSimplePossibilities } from '@/hooks/useSimplePossibilities'
 import type { ChatMessage, PossibilityResponse } from '@/types/api'
 import type { UserSettings } from '@/types/settings'
 import type { PossibilityMetadata } from '@/services/ai/PossibilityMetadataService'
-import { getModelById } from '@/services/ai/config'
-import OptionCard from './OptionCard'
-import type { ResponseOption } from '@/types'
+import Message from './Message'
+import type { Message as ChatMessageType } from '@/types/chat'
 
 interface VirtualizedPossibilitiesPanelProps {
   messages: ChatMessage[]
   settings: UserSettings
   isActive?: boolean
-  onSelectResponse?: (response: ResponseOption) => void
+  onSelectResponse?: (response: ChatMessageType) => void
   enableVirtualScrolling?: boolean
   maxTokens?: number
 }
@@ -69,86 +68,46 @@ const VirtualizedPossibilitiesPanel: React.FC<
 
   return (
     <>
-      {/* Header with statistics - outside the panel */}
+      {/* Header with statistics */}
       {isActive && (
-        <div className="px-4 py-1 text-xs text-[#888] flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <span>
-              {possibilities.length > 0
-                ? 'Possibilities'
-                : 'Preparing possibilities...'}
-            </span>
-            <div className="flex items-center gap-2 text-[#666]">
-              <span className="text-[#4ade80]">
-                ✓ {possibilities.filter((p) => p.isComplete).length}
-              </span>
-              <span className="text-[#fbbf24]">
-                ⟳ {possibilities.filter((p) => !p.isComplete).length}
-              </span>
-            </div>
-          </div>
-
-          {/* Loading indicator */}
-          {possibilities.some((p) => !p.isComplete) && (
-            <div className="flex items-center gap-1">
-              <div className="w-1 h-1 bg-[#667eea] rounded-full animate-bounce"></div>
-              <div className="w-1 h-1 bg-[#667eea] rounded-full animate-bounce delay-100"></div>
-              <div className="w-1 h-1 bg-[#667eea] rounded-full animate-bounce delay-200"></div>
-            </div>
-          )}
+        <div className="px-4 text-xs text-[#888] mb-1">
+          Possibilities {possibilities.length} of{' '}
+          {possibilities.length + availableMetadata.length}
         </div>
       )}
 
-      {/* Panel with possibilities */}
-      <div
-        className={`
-          bg-[#0f0f0f] border-t border-[#2a2a2a] 
-          flex flex-col transition-all duration-300 ease-out overflow-hidden
-          ${isActive ? 'max-h-[45vh]' : 'max-h-0'}
-        `}
-      >
-        {/* Scrollable area */}
-        <div className="flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-[#2a2a2a] scrollbar-track-transparent">
-          <div className="px-4 py-2">
-            {/* Show streaming possibilities */}
-            <div className="flex flex-col gap-2 max-w-[1200px] mx-auto">
-              {possibilities.map((possibility) => {
-                // Get model config for alias
-                const modelConfig = getModelById(possibility.metadata.model)
+      {/* Possibility messages */}
+      <div className="px-4 py-2">
+        <div className="border border-[#2a2a2a] rounded-lg p-2 bg-[#0f0f0f] flex flex-col gap-2 max-h-[45vh] overflow-y-auto" data-testid="virtualized-possibilities">
+          {possibilities.map((possibility) => {
+            const messageData: ChatMessageType = {
+              id: possibility.id,
+              role: 'assistant',
+              content: possibility.content,
+              model: possibility.metadata.model,
+              probability: possibility.probability,
+              temperature: possibility.metadata.temperature,
+              timestamp: new Date(),
+              systemInstruction: possibility.metadata.systemInstruction
+                ? possibility.metadata.systemInstruction.name
+                : undefined,
+              isPossibility: true,
+            }
 
-                // Convert to ResponseOption format for OptionCard
-                const responseOption: ResponseOption & {
-                  systemInstruction?: { name: string }
-                } = {
-                  id: possibility.id,
-                  model: {
-                    id: possibility.metadata.model,
-                    name: modelConfig?.alias || possibility.metadata.model,
-                    provider: possibility.metadata.provider,
-                    icon: '', // Will be handled by OptionCard
-                    maxTokens: 0,
-                    supportsLogprobs: false,
-                  },
-                  content: possibility.content,
-                  probability: possibility.probability,
-                  temperature: possibility.metadata.temperature,
-                  isStreaming: !possibility.isComplete,
-                  timestamp: new Date(),
-                  systemInstruction: possibility.metadata.systemInstruction
-                    ? { name: possibility.metadata.systemInstruction.name }
-                    : undefined,
-                }
-
-                return (
-                  <OptionCard
-                    key={possibility.id}
-                    response={responseOption}
-                    onSelect={onSelectResponse}
-                  />
-                )
-              })}
+            return (
+              <Message
+                key={possibility.id}
+                message={messageData}
+                onSelectPossibility={() => onSelectResponse?.(messageData)}
+                className="max-w-none"
+              />
+            )
+          })}
+          {possibilities.some((p) => !p.isComplete) && (
+            <div className="text-center text-xs text-[#888] py-2">
+              Generating more possibilities...
             </div>
-          </div>
+          )}
         </div>
       </div>
     </>

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -32,4 +32,5 @@ export const metadata: Metadata = {
     description:
       'A production-ready web application that shows multiple response possibilities from various AI models simultaneously.',
   },
+  viewport: 'width=device-width, initial-scale=1',
 }


### PR DESCRIPTION
## Summary
- add mobile viewport metadata
- improve OptionCard layout for small screens
- highlight possibility messages with dashed borders
- stream possibility responses as inline messages

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_686245eeb26c832f93dc5c08af1abcd7