### PR TITLE
Improve possibilities mobile experience

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -63,11 +63,16 @@ const Message: React.FC<ExtendedMessageProps> = ({
       <div className="flex-1">
         {/* Message Bubble */}
         <div
+          onClick={() => {
+            if (message.isPossibility) {
+              onSelectPossibility?.(message)
+            }
+          }}
           className={`border rounded-xl p-4 relative word-wrap break-word overflow-wrap break-word ${
             isUser
               ? 'bg-[#2a2a3a] border-[#3a3a4a]'
               : 'bg-[#1a1a1a] border-[#2a2a2a]'
-          }`}
+          } ${message.isPossibility ? 'border-dashed cursor-pointer hover:border-[#667eea]' : ''}`}
         >
           {/* Model Info for AI messages */}
           {!isUser &&

--- a/app/components/OptionCard.tsx
+++ b/app/components/OptionCard.tsx
@@ -51,7 +51,7 @@ const OptionCard: React.FC<OptionCardProps> = ({ response, onSelect }) => {
       "
       onClick={handleClick}
     >
-      <div className="grid grid-cols-[24px_1fr_140px_auto] gap-3 items-start">
+      <div className="grid grid-cols-[24px_1fr_auto] md:grid-cols-[24px_1fr_140px_auto] gap-3 items-start">
         {/* Provider Logo */}
         <div className="w-6 h-6 rounded-md flex items-center justify-center flex-shrink-0 bg-white p-1 overflow-hidden mt-0.5">
           {getModelIcon()}
@@ -70,12 +70,15 @@ const OptionCard: React.FC<OptionCardProps> = ({ response, onSelect }) => {
         </div>
 
         {/* Model Name */}
-        <div className="text-xs text-[#888] font-medium flex-shrink-0 mt-0.5">
+        <div className="text-xs text-[#888] font-medium flex-shrink-0 mt-0.5 hidden md:block">
           {getDisplayModelName(response.model.name)}
         </div>
 
         {/* Tags (Temperature, System Instructions, Probability) */}
         <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="md:hidden bg-[#2a2a3a] px-2 py-1 rounded text-[#888] font-medium text-xs">
+            {getDisplayModelName(response.model.name)}
+          </div>
           {response.temperature !== undefined && (
             <div
               className="bg-[#2a2a3a] px-2 py-1 rounded text-[#ffa726] font-bold text-xs"

--- a/app/components/__tests__/Message.possibilities.test.tsx
+++ b/app/components/__tests__/Message.possibilities.test.tsx
@@ -231,4 +231,23 @@ describe('Message - Possibilities', () => {
     const possibilityElement = screen.getByText('Alternative response')
     expect(() => fireEvent.click(possibilityElement)).not.toThrow()
   })
+
+  it('applies dashed border for possibility messages', () => {
+    const message = createMockMessage({
+      content: 'Possible answer',
+      isPossibility: true,
+    })
+
+    render(
+      <Message
+        message={message}
+        onSelectPossibility={mockOnSelectPossibility}
+      />
+    )
+
+    const bubble = screen
+      .getByText('Possible answer')
+      .closest('div.border') as HTMLElement
+    expect(bubble).toHaveClass('border-dashed')
+  })
 })

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -33,3 +33,8 @@ export const metadata: Metadata = {
       'A production-ready web application that shows multiple response possibilities from various AI models simultaneously.',
   },
 }
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+}


### PR DESCRIPTION
## Summary
- make possibility messages clickable with dashed border styling
- allow selecting a possibility from conversation view
- tweak OptionCard layout for small screens
- display possibilities using Message component
- add viewport metadata for better mobile scaling
- test dashed border style for possibility messages

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6864291ec374832fbfbbe2f74ae14191