### PR TITLE
Display system instruction tag for possibility messages

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -78,14 +78,29 @@ const Message: React.FC<ExtendedMessageProps> = ({
           {!isUser &&
             (message.model ||
               message.probability ||
-              message.temperature !== undefined) && (
-              <div className="absolute -top-2 right-4 bg-[#2a2a3a] px-3 py-1 rounded text-[#667eea] text-xs font-bold border border-[#3a3a4a] flex items-center gap-2">
+              message.temperature !== undefined ||
+              message.systemInstruction) && (
+              <div
+                className={`absolute right-4 bg-[#2a2a3a] px-3 py-1 rounded text-[#667eea] text-xs font-bold border border-[#3a3a4a] flex items-center gap-2 ${
+                  message.isPossibility
+                    ? 'top-0 -translate-y-full transform'
+                    : '-top-2'
+                }`}
+              >
                 {message.model && (
                   <span className="text-[#888]">{message.model}</span>
                 )}
                 {message.temperature !== undefined && (
                   <span className="text-[#ffa726]" title="Temperature">
                     T:{message.temperature?.toFixed(1)}
+                  </span>
+                )}
+                {message.systemInstruction && (
+                  <span
+                    className="bg-purple-900/30 text-purple-400 px-2 py-1 rounded"
+                    title={`System: ${message.systemInstruction}`}
+                  >
+                    {message.systemInstruction}
                   </span>
                 )}
                 {message.probability && (

--- a/app/components/__tests__/Message.test.tsx
+++ b/app/components/__tests__/Message.test.tsx
@@ -75,6 +75,18 @@ describe('Message', () => {
     expect(screen.getByText('P:85%')).toBeInTheDocument()
   })
 
+  it('shows system instruction tag when provided', () => {
+    const message = createMockMessage({
+      role: 'assistant',
+      systemInstruction: 'alpha',
+    })
+
+    render(<Message message={message} />)
+
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getByTitle('System: alpha')).toBeInTheDocument()
+  })
+
   it('does not display probability for user messages', () => {
     const message = createMockMessage({
       role: 'user',


### PR DESCRIPTION
## Summary
- show system instruction label in `Message` header when available
- test that system instruction label renders
- avoid header overlapping text in possibility messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68642df4fcf8832f929134bb4d7d4264