### PR TITLE
Fix tag overlay placement

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -31,6 +31,8 @@ const Message: React.FC<ExtendedMessageProps> = ({
           !p.content.trim().endsWith('?'))
     )
 
+  const hasModelInfo = !isUser
+
   return (
     <div className={`flex gap-3 ${className}`}>
       {/* Avatar */}
@@ -61,6 +63,19 @@ const Message: React.FC<ExtendedMessageProps> = ({
 
       {/* Message Content */}
       <div className="flex-1">
+        {hasModelInfo && (
+          <div className="mb-1 flex items-center gap-2 text-xs font-bold text-[#667eea]">
+            <span className="text-[#888]">{message.model || 'unknown'}</span>
+            <span className="text-[#ffa726]" title="Temperature">
+              T:{message.temperature !== undefined ? message.temperature?.toFixed(1) : 'unk'}
+            </span>
+            <span title="Probability Score">
+              {message.probability !== undefined && message.probability !== null
+                ? `P:${Math.round(message.probability * 100)}%`
+                : 'P:unk'}
+            </span>
+          </div>
+        )}
         {/* Message Bubble */}
         <div
           onClick={() => {
@@ -74,27 +89,6 @@ const Message: React.FC<ExtendedMessageProps> = ({
               : 'bg-[#1a1a1a] border-[#2a2a2a]'
           } ${message.isPossibility ? 'border-dashed cursor-pointer hover:border-[#667eea]' : ''}`}
         >
-          {/* Model Info for AI messages */}
-          {!isUser &&
-            (message.model ||
-              message.probability ||
-              message.temperature !== undefined) && (
-              <div className="absolute -top-2 right-4 bg-[#2a2a3a] px-3 py-1 rounded text-[#667eea] text-xs font-bold border border-[#3a3a4a] flex items-center gap-2">
-                {message.model && (
-                  <span className="text-[#888]">{message.model}</span>
-                )}
-                {message.temperature !== undefined && (
-                  <span className="text-[#ffa726]" title="Temperature">
-                    T:{message.temperature?.toFixed(1)}
-                  </span>
-                )}
-                {message.probability && (
-                  <span title="Probability Score">
-                    P:{Math.round(message.probability * 100)}%
-                  </span>
-                )}
-              </div>
-            )}
 
           {message.content && (
             <div className="text-sm leading-relaxed text-[#e0e0e0] whitespace-pre-wrap break-words">


### PR DESCRIPTION
## Summary
- remove absolute overlay style from Message
- render model info inline next to the avatar
- show placeholder tags when data missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68643473ecb8832f9e4c06b465499e31