### PR TITLE
Fix modal/menu scrolling on mobile

### DIFF
--- a/app/components/Settings.tsx
+++ b/app/components/Settings.tsx
@@ -58,7 +58,7 @@ const Settings: React.FC<SettingsProps> = ({
       className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4"
       onClick={handleBackdropClick}
     >
-      <div className="bg-[#1a1a1a] border border-[#2a2a2a] rounded-xl max-w-4xl w-full max-h-[90vh] overflow-hidden">
+      <div className="bg-[#1a1a1a] border border-[#2a2a2a] rounded-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-[#2a2a2a]">
           <h2 className="text-lg font-bold text-[#e0e0e0] flex items-center gap-2">
@@ -85,7 +85,7 @@ const Settings: React.FC<SettingsProps> = ({
         )}
 
         {/* Content */}
-        <div className="overflow-y-auto p-6">
+        <div className="overflow-y-auto p-6 flex-1">
           <ErrorBoundary>
             {activeSection === 'api-keys' && <ApiKeysPanel />}
             {activeSection === 'system-instructions' && (

--- a/app/components/menu/MenuDropdown.tsx
+++ b/app/components/menu/MenuDropdown.tsx
@@ -27,7 +27,7 @@ export const MenuDropdown: React.FC<MenuDropdownProps> = ({
   onSettingsClick,
 }) => {
   return (
-    <div className="absolute right-0 mt-2 w-[90vw] min-w-[320px] sm:w-72 bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg shadow-xl z-50">
+    <div className="absolute right-0 mt-2 w-[90vw] min-w-[320px] sm:w-72 bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg shadow-xl z-50 max-h-[90vh] overflow-y-auto">
       <UserSection
         session={session}
         status={status}


### PR DESCRIPTION
## Summary
- make settings modal scrollable by using flex and flex-1
- allow menu dropdown to scroll when content is long

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_686442dc66d8832facaebfc7d6976d64