### PR TITLE
Fix mobile viewport height

### DIFF
--- a/app/components/ChatDemo.tsx
+++ b/app/components/ChatDemo.tsx
@@ -195,7 +195,7 @@ const ChatDemo: React.FC = () => {
       onContinuePossibility={handleContinuePossibility}
       isLoading={isGenerating}
       disabled={!isSystemReady() || hasActivePossibilities()}
-      className="h-screen"
+      className="h-[100dvh]"
       settingsLoading={settingsLoading}
       apiKeysLoading={apiKeysLoading}
     />


### PR DESCRIPTION
## Summary
- ensure ChatContainer uses dynamic viewport height on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686443925384832fa9f0de44f920d16c