### PR TITLE
Add model selection settings

### DIFF
--- a/app/api/chat/completions/route.ts
+++ b/app/api/chat/completions/route.ts
@@ -20,6 +20,7 @@ const requestSchema = z.object({
   settings: z.object({
     systemPrompt: z.string().optional(),
     enabledProviders: z.array(z.string()),
+    enabledModels: z.array(z.string()).optional(),
     systemInstructions: z.array(
       z.object({
         id: z.string(),

--- a/app/components/ChatContainer.tsx
+++ b/app/components/ChatContainer.tsx
@@ -24,7 +24,7 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
   // Settings modal state
   const [showSettings, setShowSettings] = useState(false)
   const [settingsSection, setSettingsSection] = useState<
-    'api-keys' | 'system-instructions' | 'temperatures' | undefined
+    'api-keys' | 'system-instructions' | 'temperatures' | 'models' | undefined
   >()
 
   // Auth state
@@ -34,7 +34,7 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
 
   // Event handlers
   const handleOpenSettings = (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures'
+    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
   ) => {
     setSettingsSection(section)
     setShowSettings(true)

--- a/app/components/Menu.tsx
+++ b/app/components/Menu.tsx
@@ -7,7 +7,7 @@ import { MenuDropdown } from './menu/MenuDropdown'
 
 interface MenuProps {
   onOpenSettings: (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures'
+    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
   ) => void
   className?: string
 }
@@ -40,7 +40,7 @@ const Menu: React.FC<MenuProps> = ({ onOpenSettings, className = '' }) => {
 
   const handleSettingsClick = (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures'
+    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
   ) => {
     e.preventDefault()
     e.stopPropagation()

--- a/app/components/ModelsPanel.tsx
+++ b/app/components/ModelsPanel.tsx
@@ -1,0 +1,94 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { getAllModels } from '@/services/ai/config'
+import { CloudSettings } from '@/utils/cloudSettings'
+import ModelToggle from './models/ModelToggle'
+import { useApiKeys } from '../hooks/useApiKeys'
+import type { EnabledProviders, ApiKeys } from '../hooks/useApiKeys'
+
+const ModelsPanel: React.FC = () => {
+  const { data: session, status } = useSession()
+  const { validationStatus, isProviderEnabled, hasApiKey } = useApiKeys()
+  const [enabledModels, setEnabledModels] = useState<string[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  const allModels = getAllModels()
+
+  useEffect(() => {
+    if (status !== 'loading') {
+      if (session?.user) {
+        load()
+      } else {
+        setIsLoading(false)
+      }
+    }
+  }, [status, session])
+
+  const load = async () => {
+    try {
+      setIsLoading(true)
+      const saved = await CloudSettings.getEnabledModels()
+      setEnabledModels(saved || allModels.map((m) => m.id))
+    } catch (err) {
+      console.warn('Failed to load model settings:', err)
+      setEnabledModels(allModels.map((m) => m.id))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const toggle = async (id: string) => {
+    const newModels = enabledModels.includes(id)
+      ? enabledModels.filter((m) => m !== id)
+      : [...enabledModels, id]
+    setEnabledModels(newModels)
+    try {
+      await CloudSettings.setEnabledModels(newModels)
+    } catch (err) {
+      console.error('Failed to save model settings:', err)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-[#2a2a2a] rounded w-3/4" />
+          <div className="h-10 bg-[#2a2a2a] rounded" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="p-3 bg-blue-900/20 border border-blue-400/20 rounded-md text-blue-400 text-sm">
+        Select which models are used for generating possibilities. Models from
+        providers that are disabled or missing a valid API key will be ignored.
+      </div>
+      <div className="space-y-2">
+        {allModels.map((model) => {
+          const provider = model.provider as keyof EnabledProviders
+          const active =
+            isProviderEnabled(provider) &&
+            hasApiKey(provider as keyof ApiKeys) &&
+            validationStatus[provider] !== 'invalid'
+
+          return (
+            <ModelToggle
+              key={model.id}
+              model={model}
+              enabled={enabledModels.includes(model.id)}
+              onToggle={toggle}
+              disabled={!session?.user}
+              inactive={!active}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default ModelsPanel

--- a/app/components/Settings.tsx
+++ b/app/components/Settings.tsx
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react'
 import ApiKeysPanel from './ApiKeysPanel'
 import SystemInstructionsPanel from './SystemInstructionsPanel'
 import TemperaturesPanel from './TemperaturesPanel'
+import ModelsPanel from './ModelsPanel'
 import ErrorBoundary from './ErrorBoundary'
 import { CloudSettings } from '../utils/cloudSettings'
 import { useApiKeys } from '../hooks/useApiKeys'
@@ -11,10 +12,18 @@ import { useApiKeys } from '../hooks/useApiKeys'
 interface SettingsProps {
   isOpen: boolean
   onClose: () => void
-  initialSection?: 'api-keys' | 'system-instructions' | 'temperatures'
+  initialSection?:
+    | 'api-keys'
+    | 'system-instructions'
+    | 'temperatures'
+    | 'models'
 }
 
-type SettingsSection = 'api-keys' | 'system-instructions' | 'temperatures'
+type SettingsSection =
+  | 'api-keys'
+  | 'system-instructions'
+  | 'temperatures'
+  | 'models'
 
 const Settings: React.FC<SettingsProps> = ({
   isOpen,
@@ -35,6 +44,7 @@ const Settings: React.FC<SettingsProps> = ({
       label: 'System Instructions',
       icon: '📝',
     },
+    { id: 'models' as const, label: 'Models', icon: '🧠' },
     { id: 'temperatures' as const, label: 'Temperatures', icon: '🌡️' },
   ]
 
@@ -91,6 +101,7 @@ const Settings: React.FC<SettingsProps> = ({
             {activeSection === 'system-instructions' && (
               <SystemInstructionsPanel />
             )}
+            {activeSection === 'models' && <ModelsPanel />}
             {activeSection === 'temperatures' && <TemperaturesPanel />}
           </ErrorBoundary>
         </div>

--- a/app/components/__tests__/ModelsPanel.test.tsx
+++ b/app/components/__tests__/ModelsPanel.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ModelsPanel from '../ModelsPanel'
+import { useSession } from 'next-auth/react'
+import { useApiKeys } from '../../hooks/useApiKeys'
+import { CloudSettings } from '../../utils/cloudSettings'
+import { getAllModels } from '../../services/ai/config'
+
+vi.mock('next-auth/react')
+vi.mock('../../hooks/useApiKeys')
+vi.mock('../../utils/cloudSettings')
+vi.mock('../../services/ai/config')
+vi.mock('next/image', () => ({
+  default: ({ src, alt, width, height, className }: any) => (
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className={className}
+    />
+  ),
+}))
+
+const mockSession = vi.mocked(useSession)
+const mockUseApiKeys = vi.mocked(useApiKeys)
+const mockGetAllModels = vi.mocked(getAllModels)
+const mockCloudSettings = vi.mocked(CloudSettings)
+
+describe('ModelsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockSession.mockReturnValue({
+      data: { user: { id: '1', email: 'test@example.com' } },
+      status: 'authenticated',
+    } as any)
+
+    mockGetAllModels.mockReturnValue([
+      {
+        id: 'gpt-4',
+        name: 'GPT-4',
+        alias: 'gpt-4',
+        provider: 'openai',
+        description: '',
+        supportsLogprobs: true,
+        maxTokens: 8192,
+        priority: 'medium',
+      },
+      {
+        id: 'claude-3',
+        name: 'Claude 3',
+        alias: 'claude-3',
+        provider: 'anthropic',
+        description: '',
+        supportsLogprobs: true,
+        maxTokens: 8192,
+        priority: 'medium',
+      },
+    ] as any)
+
+    mockCloudSettings.getEnabledModels.mockResolvedValue(undefined as any)
+
+    mockUseApiKeys.mockReturnValue({
+      apiKeys: {},
+      enabledProviders: {
+        openai: true,
+        anthropic: false,
+        google: false,
+        mistral: false,
+        together: false,
+      },
+      validationStatus: { openai: 'valid', anthropic: null },
+      isLoading: false,
+      isAuthenticated: true,
+      saveApiKey: vi.fn(),
+      clearApiKey: vi.fn(),
+      toggleProvider: vi.fn(),
+      getApiKey: vi.fn(),
+      clearAllKeys: vi.fn(),
+      loadApiKeys: vi.fn(),
+      validateApiKey: vi.fn(),
+      isProviderEnabled: (p: any) => p === 'openai',
+      hasApiKey: (p: any) => p === 'openai',
+    } as any)
+  })
+
+  it('greys out models when provider inactive', async () => {
+    render(<ModelsPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('GPT-4')).toBeInTheDocument()
+    })
+
+    const active = screen.getByText('GPT-4').closest('button')
+    const inactive = screen.getByText('Claude 3').closest('button')
+
+    expect(active?.className).not.toContain('opacity-50')
+    expect(inactive?.className).toContain('opacity-50')
+  })
+})

--- a/app/components/__tests__/Settings.test.tsx
+++ b/app/components/__tests__/Settings.test.tsx
@@ -13,6 +13,10 @@ vi.mock('../TemperaturesPanel', () => ({
   default: () => <div data-testid="temperatures-panel">Temperatures Panel</div>,
 }))
 
+vi.mock('../ModelsPanel', () => ({
+  default: () => <div data-testid="models-panel">Models Panel</div>,
+}))
+
 // Mock CloudSettings
 const mockSystemInstructions = [
   {
@@ -283,5 +287,16 @@ describe('Settings Component', () => {
     // Check for presence of temperatures header and panel
     expect(screen.getByText('Temperatures')).toBeInTheDocument()
     expect(screen.getByTestId('temperatures-panel')).toBeInTheDocument()
+  })
+
+  it('opens to models section when specified', async () => {
+    await act(async () => {
+      render(
+        <Settings isOpen={true} onClose={() => {}} initialSection="models" />
+      )
+    })
+
+    expect(screen.getByText('Models')).toBeInTheDocument()
+    expect(screen.getByTestId('models-panel')).toBeInTheDocument()
   })
 })

--- a/app/components/chat/ChatHeader.tsx
+++ b/app/components/chat/ChatHeader.tsx
@@ -10,7 +10,7 @@ import Menu from '../Menu'
 
 export interface ChatHeaderProps {
   onOpenSettings: (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures'
+    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
   ) => void
 }
 

--- a/app/components/chat/ModalContainer.tsx
+++ b/app/components/chat/ModalContainer.tsx
@@ -12,7 +12,11 @@ import AuthPopup from '../AuthPopup'
 export interface ModalContainerProps {
   // Settings modal
   showSettings: boolean
-  settingsSection?: 'api-keys' | 'system-instructions' | 'temperatures'
+  settingsSection?:
+    | 'api-keys'
+    | 'system-instructions'
+    | 'temperatures'
+    | 'models'
   onCloseSettings: () => void
 
   // Auth popup

--- a/app/components/chat/__tests__/ModalContainer.test.tsx
+++ b/app/components/chat/__tests__/ModalContainer.test.tsx
@@ -43,6 +43,7 @@ describe('ModalContainer', () => {
       | 'api-keys'
       | 'system-instructions'
       | 'temperatures'
+      | 'models'
       | undefined,
     onCloseSettings: vi.fn(),
     showAuthPopup: false,
@@ -122,8 +123,8 @@ describe('ModalContainer', () => {
 
     it('should handle all valid settingsSection values', () => {
       const sections: Array<
-        'api-keys' | 'system-instructions' | 'temperatures'
-      > = ['api-keys', 'system-instructions', 'temperatures']
+        'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+      > = ['api-keys', 'system-instructions', 'temperatures', 'models']
 
       sections.forEach((section) => {
         const { rerender } = render(

--- a/app/components/menu/MenuDropdown.tsx
+++ b/app/components/menu/MenuDropdown.tsx
@@ -11,7 +11,7 @@ interface MenuDropdownProps {
   onSignOut: (e: React.MouseEvent) => void
   onSettingsClick: (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures'
+    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
   ) => void
 }
 

--- a/app/components/menu/MenuItems.tsx
+++ b/app/components/menu/MenuItems.tsx
@@ -9,7 +9,7 @@ interface MenuItemsProps {
   onSignOut: (e: React.MouseEvent) => void
   onSettingsClick: (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures'
+    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
   ) => void
 }
 
@@ -61,6 +61,26 @@ export const MenuItems: React.FC<MenuItemsProps> = ({
             strokeLinejoin="round"
             strokeWidth={2}
             d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      ),
+    },
+    {
+      section: 'models' as const,
+      label: 'Models',
+      description: 'Choose which models generate possibilities',
+      icon: (
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 6h16M4 10h16M4 14h16M4 18h16"
           />
         </svg>
       ),

--- a/app/components/models/ModelToggle.tsx
+++ b/app/components/models/ModelToggle.tsx
@@ -1,0 +1,50 @@
+'use client'
+import React from 'react'
+import Image from 'next/image'
+import type { ModelInfo } from '@/types/ai'
+import { getProviderLogo } from '@/utils/providerLogos'
+
+interface ModelToggleProps {
+  model: ModelInfo
+  enabled: boolean
+  onToggle: (id: string) => void
+  disabled?: boolean
+  inactive?: boolean
+}
+
+const ModelToggle: React.FC<ModelToggleProps> = ({
+  model,
+  enabled,
+  onToggle,
+  disabled,
+  inactive,
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(model.id)}
+      disabled={disabled}
+      className={`flex items-center justify-between p-3 border border-[#2a2a2a] rounded-lg w-full transition-colors ${enabled ? 'bg-[#667eea]/10' : 'bg-[#0a0a0a]'} ${disabled ? 'opacity-50 cursor-not-allowed' : inactive ? 'opacity-50' : 'hover:bg-[#2a2a2a]'}`}
+    >
+      <div className="flex items-center gap-3">
+        <Image
+          src={getProviderLogo(model.provider, 'light')}
+          alt={model.name}
+          width={20}
+          height={20}
+          className="w-5 h-5 rounded"
+        />
+        <div className="text-sm text-[#e0e0e0]">{model.name}</div>
+      </div>
+      <div
+        className={`relative w-10 h-5 rounded-full transition-colors ${enabled ? 'bg-[#667eea]' : 'bg-[#2a2a2a]'}`}
+      >
+        <div
+          className={`absolute top-0.5 w-4 h-4 bg-[#0a0a0a] rounded-full transition-transform ${enabled ? 'translate-x-5' : 'translate-x-0.5'}`}
+        />
+      </div>
+    </button>
+  )
+}
+
+export default ModelToggle

--- a/app/services/ai/ChatService.ts
+++ b/app/services/ai/ChatService.ts
@@ -146,6 +146,17 @@ export class ChatService {
         'at least one provider must be enabled'
       )
     }
+
+    if (settings.enabledModels) {
+      const enabledModels = this.extractEnabledModels(settings)
+      if (enabledModels.length === 0) {
+        throw new ValidationError(
+          'enabledModels',
+          enabledModels,
+          'at least one model must be selected'
+        )
+      }
+    }
   }
 
   private extractEnabledProviders(settings: UserSettings): string[] {
@@ -165,17 +176,26 @@ export class ChatService {
     }
   }
 
+  private extractEnabledModels(settings: UserSettings): string[] {
+    if (Array.isArray(settings.enabledModels)) {
+      return settings.enabledModels
+    }
+    return []
+  }
+
   private buildChatRequest(
     messages: ChatMessage[],
     settings: UserSettings
   ): ChatCompletionRequest {
     const enabledProviders = this.extractEnabledProviders(settings)
+    const enabledModels = this.extractEnabledModels(settings)
 
     return {
       messages,
       settings: {
         systemPrompt: settings.systemPrompt,
         enabledProviders,
+        enabledModels: enabledModels.length > 0 ? enabledModels : undefined,
         systemInstructions: settings.systemInstructions || [],
         temperatures: settings.temperatures?.map((t) => t.value) || [
           0.3, 0.7, 1.0,

--- a/app/services/ai/permutations.ts
+++ b/app/services/ai/permutations.ts
@@ -26,8 +26,8 @@ export class PermutationGenerator {
 
     // For each enabled provider
     for (const provider of settings.enabledProviders) {
-      // Get models for this provider
-      const models = this.getModelsForProvider(provider)
+      // Get models for this provider, filtered by enabled models if provided
+      const models = this.getModelsForProvider(provider, settings.enabledModels)
 
       // For each model
       for (const model of models) {
@@ -64,8 +64,11 @@ export class PermutationGenerator {
   /**
    * Get available models for a provider
    */
-  private getModelsForProvider(provider: string) {
-    return getAllModels().filter((model) => model.provider === provider)
+  private getModelsForProvider(provider: string, enabled?: string[]) {
+    return getAllModels().filter(
+      (model) =>
+        model.provider === provider && (!enabled || enabled.includes(model.id))
+    )
   }
 
   /**
@@ -108,7 +111,10 @@ export class PermutationGenerator {
     }
 
     for (const provider of settings.enabledProviders) {
-      const modelCount = this.getModelsForProvider(provider).length
+      const modelCount = this.getModelsForProvider(
+        provider,
+        settings.enabledModels
+      ).length
       const temperatureCount = settings.temperatures.length
       const instructionCount =
         settings.systemInstructions.length > 0

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -10,6 +10,7 @@ export interface ChatCompletionRequest {
   settings: {
     systemPrompt?: string
     enabledProviders: string[]
+    enabledModels?: string[]
     systemInstructions: SystemInstruction[]
     temperatures: number[]
   }

--- a/app/types/settings.ts
+++ b/app/types/settings.ts
@@ -15,6 +15,7 @@ export interface UserSettings {
   enabledProviders?: string // JSON stringified EnabledProviders
   systemInstructions?: SystemInstruction[]
   temperatures?: Temperature[]
+  enabledModels?: string[]
   possibilityMultiplier?: number // How many instances of each permutation to generate (default 1)
   [key: string]: any // Allow for future settings
 }

--- a/app/utils/cloudSettings.ts
+++ b/app/utils/cloudSettings.ts
@@ -103,6 +103,16 @@ export class CloudSettings {
     await this.updateSettings({ enabledProviders: providers })
   }
 
+  // Model preferences
+  static async getEnabledModels(): Promise<string[] | undefined> {
+    const settings = await this.getSettings()
+    return settings.enabledModels
+  }
+
+  static async setEnabledModels(models: string[]): Promise<void> {
+    await this.updateSettings({ enabledModels: models })
+  }
+
   // Reset all settings to defaults
   static async resetToDefaults(): Promise<void> {
     const defaultInstructions: SystemInstruction[] = [


### PR DESCRIPTION
## Summary
- allow choosing which models generate possibilities
- add `Models` panel in Settings with toggles for each model
- persist user choices via CloudSettings
- extend API and ChatService to include `enabledModels`
- support new `models` section in menu and modal components
- update tests
- gray out models when provider has no API key or is disabled

## Testing
- `npm run format`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686447995410832fbda259182ff2623c