### PR TITLE
Fix system instruction enablement in permutations

### DIFF
--- a/app/services/ai/__tests__/permutations.test.ts
+++ b/app/services/ai/__tests__/permutations.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { PermutationGenerator } from '../permutations'
+import { DEFAULT_SYSTEM_INSTRUCTION } from '@/constants/defaults'
+import type { ChatCompletionRequest } from '@/types/api'
+import type { SystemInstruction } from '@/types/settings'
+
+describe('PermutationGenerator system instructions', () => {
+  const baseSettings: ChatCompletionRequest['settings'] = {
+    systemPrompt: 'prompt',
+    enabledProviders: ['openai'],
+    enabledModels: ['gpt-4'],
+    temperatures: [0.7],
+    systemInstructions: [],
+  }
+
+  it('includes only enabled instructions', () => {
+    const instructions: SystemInstruction[] = [
+      { id: '1', name: 'one', content: '1', enabled: true },
+      { id: '2', name: 'two', content: '2', enabled: false },
+    ]
+    const generator = new PermutationGenerator()
+    const perms = generator.generatePermutations({
+      ...baseSettings,
+      systemInstructions: instructions,
+    })
+    expect(perms).toHaveLength(1)
+    expect(perms[0].systemInstruction?.id).toBe('1')
+  })
+
+  it('falls back to default when none enabled', () => {
+    const instructions: SystemInstruction[] = [
+      { id: '1', name: 'one', content: '1', enabled: false },
+    ]
+    const generator = new PermutationGenerator()
+    const perms = generator.generatePermutations({
+      ...baseSettings,
+      systemInstructions: instructions,
+    })
+    expect(perms).toHaveLength(1)
+    expect(perms[0].systemInstruction?.id).toBe(DEFAULT_SYSTEM_INSTRUCTION.id)
+  })
+})

--- a/app/services/ai/permutations.ts
+++ b/app/services/ai/permutations.ts
@@ -34,9 +34,12 @@ export class PermutationGenerator {
         // For each temperature
         for (const temperature of settings.temperatures) {
           // For each system instruction - ensure we always have at least one
+          const enabledInstructions = settings.systemInstructions.filter(
+            (inst) => inst.enabled
+          )
           const instructions: SystemInstruction[] =
-            settings.systemInstructions.length > 0
-              ? settings.systemInstructions
+            enabledInstructions.length > 0
+              ? enabledInstructions
               : [DEFAULT_SYSTEM_INSTRUCTION]
 
           for (const instruction of instructions) {
@@ -116,10 +119,11 @@ export class PermutationGenerator {
         settings.enabledModels
       ).length
       const temperatureCount = settings.temperatures.length
+      const enabledInstructions = settings.systemInstructions.filter(
+        (inst) => inst.enabled
+      )
       const instructionCount =
-        settings.systemInstructions.length > 0
-          ? settings.systemInstructions.length
-          : 1 // Default instruction
+        enabledInstructions.length > 0 ? enabledInstructions.length : 1
 
       count += modelCount * temperatureCount * instructionCount
     }


### PR DESCRIPTION
## Summary
- respect `enabled` flag when generating permutations
- update permutation count logic
- add regression tests for system instruction filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686456918b4c832f8632016c4e698731