### PR TITLE
Add configurable possibility defaults

### DIFF
--- a/app/components/ChatContainer.tsx
+++ b/app/components/ChatContainer.tsx
@@ -24,7 +24,12 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
   // Settings modal state
   const [showSettings, setShowSettings] = useState(false)
   const [settingsSection, setSettingsSection] = useState<
-    'api-keys' | 'system-instructions' | 'temperatures' | 'models' | undefined
+    | 'api-keys'
+    | 'system-instructions'
+    | 'temperatures'
+    | 'models'
+    | 'possibility-defaults'
+    | undefined
   >()
 
   // Auth state
@@ -34,7 +39,12 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
 
   // Event handlers
   const handleOpenSettings = (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'possibility-defaults'
   ) => {
     setSettingsSection(section)
     setShowSettings(true)

--- a/app/components/Menu.tsx
+++ b/app/components/Menu.tsx
@@ -7,7 +7,12 @@ import { MenuDropdown } from './menu/MenuDropdown'
 
 interface MenuProps {
   onOpenSettings: (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'possibility-defaults'
   ) => void
   className?: string
 }
@@ -40,7 +45,12 @@ const Menu: React.FC<MenuProps> = ({ onOpenSettings, className = '' }) => {
 
   const handleSettingsClick = (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'possibility-defaults'
   ) => {
     e.preventDefault()
     e.stopPropagation()

--- a/app/components/MessageWithIndependentPossibilities.tsx
+++ b/app/components/MessageWithIndependentPossibilities.tsx
@@ -204,7 +204,10 @@ const MessageWithIndependentPossibilities: React.FC<
                   isActive={true}
                   onSelectResponse={handleSelectResponse}
                   enableVirtualScrolling={true}
-                  maxTokens={TOKEN_LIMITS.POSSIBILITY_DEFAULT}
+                  maxTokens={
+                    settings.possibilityDefaults?.tokensPerPossibility ??
+                    TOKEN_LIMITS.POSSIBILITY_DEFAULT
+                  }
                 />
               </div>
             )}

--- a/app/components/PossibilityDefaultsPanel.tsx
+++ b/app/components/PossibilityDefaultsPanel.tsx
@@ -1,0 +1,142 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { CloudSettings } from '../utils/cloudSettings'
+import type { PossibilityDefaults } from '../types/settings'
+import { TOKEN_LIMITS, DEFAULT_INITIAL_POSSIBILITIES } from '../services/ai/config'
+
+const defaultValues: PossibilityDefaults = {
+  maxInitial: DEFAULT_INITIAL_POSSIBILITIES,
+  tokensPerPossibility: TOKEN_LIMITS.POSSIBILITY_DEFAULT,
+  tokensReasoning: TOKEN_LIMITS.POSSIBILITY_REASONING,
+  tokensContinuation: TOKEN_LIMITS.CONTINUATION_DEFAULT,
+}
+
+const PossibilityDefaultsPanel: React.FC = () => {
+  const { data: session, status } = useSession()
+  const [values, setValues] = useState<PossibilityDefaults>(defaultValues)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    if (status !== 'loading' && session?.user) {
+      load()
+    } else if (status !== 'loading') {
+      setIsLoading(false)
+    }
+  }, [session, status])
+
+  const load = async () => {
+    try {
+      setIsLoading(true)
+      const saved = await CloudSettings.getPossibilityDefaults()
+      setValues(saved)
+    } catch (err) {
+      console.warn('Failed to load possibility defaults:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleChange = (key: keyof PossibilityDefaults, val: number) => {
+    setValues({ ...values, [key]: val })
+  }
+
+  const handleSave = async () => {
+    try {
+      await CloudSettings.setPossibilityDefaults(values)
+    } catch (err) {
+      console.error('Error saving defaults:', err)
+    }
+  }
+
+  const handleReset = async () => {
+    try {
+      await CloudSettings.setPossibilityDefaults(defaultValues)
+      setValues(defaultValues)
+    } catch (err) {
+      console.error('Error resetting defaults:', err)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-[#2a2a2a] rounded w-3/4"></div>
+          <div className="h-32 bg-[#2a2a2a] rounded"></div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!session?.user) {
+    return (
+      <div className="text-center py-8">
+        <div className="text-[#666] text-sm">Sign in to adjust defaults</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-4">
+        <div className="flex items-center gap-4">
+          <label className="w-56 text-sm text-[#e0e0e0]">Initial possibilities</label>
+          <input
+            type="number"
+            min={1}
+            value={values.maxInitial}
+            onChange={(e) => handleChange('maxInitial', Number(e.target.value))}
+            className="bg-[#111] border border-[#333] rounded px-2 py-1 w-24 text-sm"
+          />
+        </div>
+        <div className="flex items-center gap-4">
+          <label className="w-56 text-sm text-[#e0e0e0]">Tokens per possibility</label>
+          <input
+            type="number"
+            min={1}
+            value={values.tokensPerPossibility}
+            onChange={(e) => handleChange('tokensPerPossibility', Number(e.target.value))}
+            className="bg-[#111] border border-[#333] rounded px-2 py-1 w-24 text-sm"
+          />
+        </div>
+        <div className="flex items-center gap-4">
+          <label className="w-56 text-sm text-[#e0e0e0]">Tokens for reasoning models</label>
+          <input
+            type="number"
+            min={1}
+            value={values.tokensReasoning}
+            onChange={(e) => handleChange('tokensReasoning', Number(e.target.value))}
+            className="bg-[#111] border border-[#333] rounded px-2 py-1 w-24 text-sm"
+          />
+        </div>
+        <div className="flex items-center gap-4">
+          <label className="w-56 text-sm text-[#e0e0e0]">Tokens for continuations</label>
+          <input
+            type="number"
+            min={1}
+            value={values.tokensContinuation}
+            onChange={(e) => handleChange('tokensContinuation', Number(e.target.value))}
+            className="bg-[#111] border border-[#333] rounded px-2 py-1 w-24 text-sm"
+          />
+        </div>
+      </div>
+      <div className="pt-4 border-t border-[#2a2a2a] flex justify-end gap-2">
+        <button
+          onClick={handleReset}
+          className="px-4 py-2 text-sm text-[#555] hover:text-[#777] bg-transparent hover:bg-[#1a1a1a] rounded-md transition-colors border border-[#333] hover:border-[#444]"
+        >
+          Reset
+        </button>
+        <button
+          onClick={handleSave}
+          className="px-4 py-2 text-sm text-white bg-[#667eea] hover:bg-[#5a6fd8] rounded-md transition-colors"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default PossibilityDefaultsPanel

--- a/app/components/Settings.tsx
+++ b/app/components/Settings.tsx
@@ -5,6 +5,7 @@ import ApiKeysPanel from './ApiKeysPanel'
 import SystemInstructionsPanel from './SystemInstructionsPanel'
 import TemperaturesPanel from './TemperaturesPanel'
 import ModelsPanel from './ModelsPanel'
+import PossibilityDefaultsPanel from './PossibilityDefaultsPanel'
 import ErrorBoundary from './ErrorBoundary'
 import { CloudSettings } from '../utils/cloudSettings'
 import { useApiKeys } from '../hooks/useApiKeys'
@@ -17,6 +18,7 @@ interface SettingsProps {
     | 'system-instructions'
     | 'temperatures'
     | 'models'
+    | 'possibility-defaults'
 }
 
 type SettingsSection =
@@ -24,6 +26,7 @@ type SettingsSection =
   | 'system-instructions'
   | 'temperatures'
   | 'models'
+  | 'possibility-defaults'
 
 const Settings: React.FC<SettingsProps> = ({
   isOpen,
@@ -46,6 +49,11 @@ const Settings: React.FC<SettingsProps> = ({
     },
     { id: 'models' as const, label: 'Models', icon: '🧠' },
     { id: 'temperatures' as const, label: 'Temperatures', icon: '🌡️' },
+    {
+      id: 'possibility-defaults' as const,
+      label: 'Possibilities',
+      icon: '✨',
+    },
   ]
 
   // Update active section when initialSection changes
@@ -103,6 +111,9 @@ const Settings: React.FC<SettingsProps> = ({
             )}
             {activeSection === 'models' && <ModelsPanel />}
             {activeSection === 'temperatures' && <TemperaturesPanel />}
+            {activeSection === 'possibility-defaults' && (
+              <PossibilityDefaultsPanel />
+            )}
           </ErrorBoundary>
         </div>
       </div>

--- a/app/components/VirtualizedPossibilitiesPanel.tsx
+++ b/app/components/VirtualizedPossibilitiesPanel.tsx
@@ -3,7 +3,11 @@ import { useSimplePossibilities } from '@/hooks/useSimplePossibilities'
 import type { ChatMessage } from '@/types/api'
 import type { UserSettings } from '@/types/settings'
 import type { PossibilityMetadata } from '@/services/ai/PossibilityMetadataService'
-import { getModelById } from '@/services/ai/config'
+import {
+  getModelById,
+  TOKEN_LIMITS,
+  DEFAULT_INITIAL_POSSIBILITIES,
+} from '@/services/ai/config'
 import Message from './Message'
 import type { Message as ChatMessageType } from '../types/chat'
 
@@ -53,7 +57,12 @@ const VirtualizedPossibilitiesPanel: React.FC<
       // loadPossibility will handle duplicate prevention internally
       const allMetadata =
         new (require('@/services/ai/PossibilityMetadataService').PossibilityMetadataService)().generatePrioritizedMetadata(
-          settings
+          settings,
+          {
+            maxTokens:
+              settings.possibilityDefaults?.tokensPerPossibility ??
+              TOKEN_LIMITS.POSSIBILITY_DEFAULT,
+          }
         )
 
       const highPriority = allMetadata
@@ -61,7 +70,11 @@ const VirtualizedPossibilitiesPanel: React.FC<
           (m: PossibilityMetadata) =>
             m.priority === 'high' || m.priority === 'medium'
         )
-        .slice(0, 12)
+        .slice(
+          0,
+          settings.possibilityDefaults?.maxInitial ??
+            DEFAULT_INITIAL_POSSIBILITIES
+        )
 
       highPriority.forEach((meta: PossibilityMetadata) =>
         loadPossibility(meta.id)

--- a/app/components/chat/ChatHeader.tsx
+++ b/app/components/chat/ChatHeader.tsx
@@ -10,7 +10,12 @@ import Menu from '../Menu'
 
 export interface ChatHeaderProps {
   onOpenSettings: (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'possibility-defaults'
   ) => void
 }
 

--- a/app/components/chat/ModalContainer.tsx
+++ b/app/components/chat/ModalContainer.tsx
@@ -17,6 +17,7 @@ export interface ModalContainerProps {
     | 'system-instructions'
     | 'temperatures'
     | 'models'
+    | 'possibility-defaults'
   onCloseSettings: () => void
 
   // Auth popup

--- a/app/components/menu/MenuDropdown.tsx
+++ b/app/components/menu/MenuDropdown.tsx
@@ -11,7 +11,12 @@ interface MenuDropdownProps {
   onSignOut: (e: React.MouseEvent) => void
   onSettingsClick: (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'possibility-defaults'
   ) => void
 }
 

--- a/app/components/menu/MenuItems.tsx
+++ b/app/components/menu/MenuItems.tsx
@@ -9,7 +9,12 @@ interface MenuItemsProps {
   onSignOut: (e: React.MouseEvent) => void
   onSettingsClick: (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'possibility-defaults'
   ) => void
 }
 
@@ -102,6 +107,16 @@ export const MenuItems: React.FC<MenuItemsProps> = ({
             strokeWidth={2}
             d="M13 10V3L4 14h7v7l9-11h-7z"
           />
+        </svg>
+      ),
+    },
+    {
+      section: 'possibility-defaults' as const,
+      label: 'Possibilities',
+      description: 'Generation limits',
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
         </svg>
       ),
     },

--- a/app/hooks/useSimplePossibilities.ts
+++ b/app/hooks/useSimplePossibilities.ts
@@ -111,7 +111,11 @@ export function useSimplePossibilities(
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ messages, permutation: meta }),
+            body: JSON.stringify({
+              messages,
+              permutation: meta,
+              options: { maxTokens: meta.estimatedTokens },
+            }),
             signal: abortController.signal,
           })
 

--- a/app/services/ai/__tests__/permutations.test.ts
+++ b/app/services/ai/__tests__/permutations.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { PermutationGenerator } from '../permutations'
+import { DEFAULT_SYSTEM_INSTRUCTION } from '@/constants/defaults'
+import type { ChatCompletionRequest } from '@/types/api'
+import type { SystemInstruction } from '@/types/settings'
+
+describe('PermutationGenerator system instructions', () => {
+  const baseSettings: ChatCompletionRequest['settings'] = {
+    systemPrompt: 'prompt',
+    enabledProviders: ['openai'],
+    enabledModels: ['gpt-4'],
+    temperatures: [0.7],
+    systemInstructions: [],
+  }
+
+  it('includes only enabled instructions', () => {
+    const instructions: SystemInstruction[] = [
+      { id: '1', name: 'one', content: '1', enabled: true },
+      { id: '2', name: 'two', content: '2', enabled: false },
+    ]
+    const generator = new PermutationGenerator()
+    const perms = generator.generatePermutations({
+      ...baseSettings,
+      systemInstructions: instructions,
+    })
+    expect(perms).toHaveLength(1)
+    expect(perms[0].systemInstruction?.id).toBe('1')
+  })
+
+  it('falls back to default when none enabled', () => {
+    const instructions: SystemInstruction[] = [
+      { id: '1', name: 'one', content: '1', enabled: false },
+    ]
+    const generator = new PermutationGenerator()
+    const perms = generator.generatePermutations({
+      ...baseSettings,
+      systemInstructions: instructions,
+    })
+    expect(perms).toHaveLength(1)
+    expect(perms[0].systemInstruction?.id).toBe(DEFAULT_SYSTEM_INSTRUCTION.id)
+  })
+})

--- a/app/services/ai/config.ts
+++ b/app/services/ai/config.ts
@@ -8,6 +8,9 @@ export const TOKEN_LIMITS = {
   CONTINUATION_DEFAULT: 1000, // Additional tokens when continuing from a possibility
 } as const
 
+// Default number of possibilities to load initially
+export const DEFAULT_INITIAL_POSSIBILITIES = 12
+
 export const MODEL_CONFIGS: Record<ProviderType, ModelInfo[]> = {
   openai: [
     {

--- a/app/services/ai/permutations.ts
+++ b/app/services/ai/permutations.ts
@@ -34,9 +34,12 @@ export class PermutationGenerator {
         // For each temperature
         for (const temperature of settings.temperatures) {
           // For each system instruction - ensure we always have at least one
+          const enabledInstructions = settings.systemInstructions.filter(
+            (inst) => inst.enabled
+          )
           const instructions: SystemInstruction[] =
-            settings.systemInstructions.length > 0
-              ? settings.systemInstructions
+            enabledInstructions.length > 0
+              ? enabledInstructions
               : [DEFAULT_SYSTEM_INSTRUCTION]
 
           for (const instruction of instructions) {
@@ -116,10 +119,11 @@ export class PermutationGenerator {
         settings.enabledModels
       ).length
       const temperatureCount = settings.temperatures.length
+      const enabledInstructions = settings.systemInstructions.filter(
+        (inst) => inst.enabled
+      )
       const instructionCount =
-        settings.systemInstructions.length > 0
-          ? settings.systemInstructions.length
-          : 1 // Default instruction
+        enabledInstructions.length > 0 ? enabledInstructions.length : 1
 
       count += modelCount * temperatureCount * instructionCount
     }

--- a/app/types/settings.ts
+++ b/app/types/settings.ts
@@ -10,6 +10,13 @@ export interface Temperature {
   value: number
 }
 
+export interface PossibilityDefaults {
+  maxInitial: number
+  tokensPerPossibility: number
+  tokensReasoning: number
+  tokensContinuation: number
+}
+
 export interface UserSettings {
   systemPrompt?: string
   enabledProviders?: string // JSON stringified EnabledProviders
@@ -17,5 +24,6 @@ export interface UserSettings {
   temperatures?: Temperature[]
   enabledModels?: string[]
   possibilityMultiplier?: number // How many instances of each permutation to generate (default 1)
+  possibilityDefaults?: PossibilityDefaults
   [key: string]: any // Allow for future settings
 }

--- a/app/utils/cloudSettings.ts
+++ b/app/utils/cloudSettings.ts
@@ -1,7 +1,16 @@
-import { SystemInstruction, Temperature, UserSettings } from '../types/settings'
+import {
+  SystemInstruction,
+  Temperature,
+  UserSettings,
+  PossibilityDefaults,
+} from '../types/settings'
 import { DEFAULT_SYSTEM_INSTRUCTION } from '../constants/defaults'
+import {
+  TOKEN_LIMITS,
+  DEFAULT_INITIAL_POSSIBILITIES,
+} from '../services/ai/config'
 
-export type { SystemInstruction, Temperature, UserSettings }
+export type { SystemInstruction, Temperature, UserSettings, PossibilityDefaults }
 
 export class CloudSettings {
   static async getSettings(): Promise<UserSettings> {
@@ -113,6 +122,25 @@ export class CloudSettings {
     await this.updateSettings({ enabledModels: models })
   }
 
+  // Possibility defaults
+  static async getPossibilityDefaults(): Promise<PossibilityDefaults> {
+    const settings = await this.getSettings()
+    return (
+      settings.possibilityDefaults || {
+        maxInitial: DEFAULT_INITIAL_POSSIBILITIES,
+        tokensPerPossibility: TOKEN_LIMITS.POSSIBILITY_DEFAULT,
+        tokensReasoning: TOKEN_LIMITS.POSSIBILITY_REASONING,
+        tokensContinuation: TOKEN_LIMITS.CONTINUATION_DEFAULT,
+      }
+    )
+  }
+
+  static async setPossibilityDefaults(
+    defaults: PossibilityDefaults
+  ): Promise<void> {
+    await this.updateSettings({ possibilityDefaults: defaults })
+  }
+
   // Reset all settings to defaults
   static async resetToDefaults(): Promise<void> {
     const defaultInstructions: SystemInstruction[] = [
@@ -132,9 +160,17 @@ export class CloudSettings {
       },
     ]
 
+    const defaultPossibilityDefaults: PossibilityDefaults = {
+      maxInitial: DEFAULT_INITIAL_POSSIBILITIES,
+      tokensPerPossibility: TOKEN_LIMITS.POSSIBILITY_DEFAULT,
+      tokensReasoning: TOKEN_LIMITS.POSSIBILITY_REASONING,
+      tokensContinuation: TOKEN_LIMITS.CONTINUATION_DEFAULT,
+    }
+
     await this.updateSettings({
       systemInstructions: defaultInstructions,
       temperatures: defaultTemperatures,
+      possibilityDefaults: defaultPossibilityDefaults,
     })
   }
 }


### PR DESCRIPTION
## Summary
- expose default token and possibility counts in config
- extend user settings for possibility defaults
- add ability to load/save possibility defaults via CloudSettings
- send token limits when loading possibilities
- auto-load initial possibilities based on user defaults
- allow customizing via new Possibility Defaults settings panel
- add menu option and wiring for Possibility Defaults
- merge latest main branch fixes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686454e3d950832f81c8618a81e00075