### PR TITLE
Add generation defaults customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,18 @@ export default tseslint.config({
   },
 })
 ```
+
+## Possibility Generation Defaults
+
+The application uses several configuration values to control how possibilities are generated:
+
+- **Initial possibilities loaded**: `maxInitialPossibilities` (default `12`)
+- **Tokens per possibility**: `possibilityTokens` (default `100`)
+- **Tokens for reasoning models**: `reasoningTokens` (default `1500`)
+- **Tokens for continued generation**: `continuationTokens` (default `1000`)
+- **Possibility multiplier**: `possibilityMultiplier` (default `1`)
+- **Early high-priority cutoff**: first `8` possibilities
+- **Concurrent generation limit**: `6` active requests
+- **Retry attempts**: `3` automatic retries on failure
+
+You can customize the token limits and max initial possibilities in the **Generation** section of the settings menu.

--- a/app/components/ChatContainer.tsx
+++ b/app/components/ChatContainer.tsx
@@ -24,7 +24,12 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
   // Settings modal state
   const [showSettings, setShowSettings] = useState(false)
   const [settingsSection, setSettingsSection] = useState<
-    'api-keys' | 'system-instructions' | 'temperatures' | 'models' | undefined
+    | 'api-keys'
+    | 'system-instructions'
+    | 'temperatures'
+    | 'models'
+    | 'generation'
+    | undefined
   >()
 
   // Auth state
@@ -34,7 +39,12 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
 
   // Event handlers
   const handleOpenSettings = (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'generation'
   ) => {
     setSettingsSection(section)
     setShowSettings(true)

--- a/app/components/GenerationSettingsPanel.tsx
+++ b/app/components/GenerationSettingsPanel.tsx
@@ -1,0 +1,144 @@
+'use client'
+import React, { useState, useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { CloudSettings } from '../utils/cloudSettings'
+import { TOKEN_LIMITS } from '../services/ai/config'
+
+type GenerationDefaults = {
+  possibilityTokens: number
+  reasoningTokens: number
+  continuationTokens: number
+  maxInitialPossibilities: number
+}
+
+const GenerationSettingsPanel: React.FC = () => {
+  const { data: session, status } = useSession()
+  const [values, setValues] = useState<GenerationDefaults>({
+    possibilityTokens: TOKEN_LIMITS.POSSIBILITY_DEFAULT,
+    reasoningTokens: TOKEN_LIMITS.POSSIBILITY_REASONING,
+    continuationTokens: TOKEN_LIMITS.CONTINUATION_DEFAULT,
+    maxInitialPossibilities: 12,
+  })
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    if (status !== 'loading') {
+      CloudSettings.getGenerationDefaults()
+        .then((v) => setValues(v))
+        .finally(() => setIsLoading(false))
+    }
+  }, [status])
+
+  const handleChange = (key: string, val: number) => {
+    setValues((prev) => ({ ...prev, [key]: val }))
+  }
+
+  const handleSave = async () => {
+    await CloudSettings.setGenerationDefaults(values)
+  }
+
+  const handleReset = async () => {
+    const defaults = {
+      possibilityTokens: TOKEN_LIMITS.POSSIBILITY_DEFAULT,
+      reasoningTokens: TOKEN_LIMITS.POSSIBILITY_REASONING,
+      continuationTokens: TOKEN_LIMITS.CONTINUATION_DEFAULT,
+      maxInitialPossibilities: 12,
+    }
+    await CloudSettings.setGenerationDefaults(defaults)
+    setValues(defaults)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-4 bg-[#2a2a2a] rounded w-3/4" />
+          <div className="h-16 bg-[#2a2a2a] rounded" />
+        </div>
+      </div>
+    )
+  }
+
+  const inputClass =
+    'w-full px-3 py-2 bg-[#1a1a1a] border border-[#333] rounded-md text-sm text-[#e0e0e0]'
+
+  return (
+    <div className="space-y-6">
+      <div className="p-3 bg-blue-900/20 border border-blue-400/20 rounded-md text-blue-400 text-sm">
+        Configure token limits and how many possibilities load automatically.
+      </div>
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm mb-1">
+            Default tokens per possibility
+          </label>
+          <input
+            type="number"
+            className={inputClass}
+            value={values.possibilityTokens}
+            onChange={(e) =>
+              handleChange('possibilityTokens', parseInt(e.target.value))
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">
+            Tokens for reasoning models
+          </label>
+          <input
+            type="number"
+            className={inputClass}
+            value={values.reasoningTokens}
+            onChange={(e) =>
+              handleChange('reasoningTokens', parseInt(e.target.value))
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">
+            Tokens for continued generation
+          </label>
+          <input
+            type="number"
+            className={inputClass}
+            value={values.continuationTokens}
+            onChange={(e) =>
+              handleChange('continuationTokens', parseInt(e.target.value))
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">
+            Initial possibilities to load
+          </label>
+          <input
+            type="number"
+            className={inputClass}
+            value={values.maxInitialPossibilities}
+            onChange={(e) =>
+              handleChange('maxInitialPossibilities', parseInt(e.target.value))
+            }
+          />
+        </div>
+      </div>
+      {session?.user && (
+        <div className="pt-4 border-t border-[#2a2a2a] flex justify-end space-x-3">
+          <button
+            onClick={handleReset}
+            className="px-4 py-2 text-sm text-[#555] hover:text-[#777] bg-transparent hover:bg-[#1a1a1a] rounded-md transition-colors border border-[#333] hover:border-[#444]"
+          >
+            Reset
+          </button>
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 text-sm text-[#667eea] hover:text-[#5a6fd8] bg-[#667eea]/10 hover:bg-[#667eea]/20 rounded-md transition-colors"
+          >
+            Save
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GenerationSettingsPanel

--- a/app/components/Menu.tsx
+++ b/app/components/Menu.tsx
@@ -7,7 +7,12 @@ import { MenuDropdown } from './menu/MenuDropdown'
 
 interface MenuProps {
   onOpenSettings: (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'generation'
   ) => void
   className?: string
 }
@@ -40,7 +45,12 @@ const Menu: React.FC<MenuProps> = ({ onOpenSettings, className = '' }) => {
 
   const handleSettingsClick = (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'generation'
   ) => {
     e.preventDefault()
     e.stopPropagation()

--- a/app/components/Settings.tsx
+++ b/app/components/Settings.tsx
@@ -5,6 +5,7 @@ import ApiKeysPanel from './ApiKeysPanel'
 import SystemInstructionsPanel from './SystemInstructionsPanel'
 import TemperaturesPanel from './TemperaturesPanel'
 import ModelsPanel from './ModelsPanel'
+import GenerationSettingsPanel from './GenerationSettingsPanel'
 import ErrorBoundary from './ErrorBoundary'
 import { CloudSettings } from '../utils/cloudSettings'
 import { useApiKeys } from '../hooks/useApiKeys'
@@ -17,6 +18,7 @@ interface SettingsProps {
     | 'system-instructions'
     | 'temperatures'
     | 'models'
+    | 'generation'
 }
 
 type SettingsSection =
@@ -24,6 +26,7 @@ type SettingsSection =
   | 'system-instructions'
   | 'temperatures'
   | 'models'
+  | 'generation'
 
 const Settings: React.FC<SettingsProps> = ({
   isOpen,
@@ -46,6 +49,7 @@ const Settings: React.FC<SettingsProps> = ({
     },
     { id: 'models' as const, label: 'Models', icon: '🧠' },
     { id: 'temperatures' as const, label: 'Temperatures', icon: '🌡️' },
+    { id: 'generation' as const, label: 'Generation', icon: '⚙️' },
   ]
 
   // Update active section when initialSection changes
@@ -103,6 +107,7 @@ const Settings: React.FC<SettingsProps> = ({
             )}
             {activeSection === 'models' && <ModelsPanel />}
             {activeSection === 'temperatures' && <TemperaturesPanel />}
+            {activeSection === 'generation' && <GenerationSettingsPanel />}
           </ErrorBoundary>
         </div>
       </div>

--- a/app/components/VirtualizedPossibilitiesPanel.tsx
+++ b/app/components/VirtualizedPossibilitiesPanel.tsx
@@ -61,7 +61,7 @@ const VirtualizedPossibilitiesPanel: React.FC<
           (m: PossibilityMetadata) =>
             m.priority === 'high' || m.priority === 'medium'
         )
-        .slice(0, 12)
+        .slice(0, settings.maxInitialPossibilities ?? 12)
 
       highPriority.forEach((meta: PossibilityMetadata) =>
         loadPossibility(meta.id)

--- a/app/components/chat/ChatHeader.tsx
+++ b/app/components/chat/ChatHeader.tsx
@@ -10,7 +10,12 @@ import Menu from '../Menu'
 
 export interface ChatHeaderProps {
   onOpenSettings: (
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'generation'
   ) => void
 }
 

--- a/app/components/chat/ModalContainer.tsx
+++ b/app/components/chat/ModalContainer.tsx
@@ -17,6 +17,7 @@ export interface ModalContainerProps {
     | 'system-instructions'
     | 'temperatures'
     | 'models'
+    | 'generation'
   onCloseSettings: () => void
 
   // Auth popup

--- a/app/components/menu/MenuDropdown.tsx
+++ b/app/components/menu/MenuDropdown.tsx
@@ -11,7 +11,12 @@ interface MenuDropdownProps {
   onSignOut: (e: React.MouseEvent) => void
   onSettingsClick: (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'generation'
   ) => void
 }
 

--- a/app/components/menu/MenuItems.tsx
+++ b/app/components/menu/MenuItems.tsx
@@ -9,7 +9,12 @@ interface MenuItemsProps {
   onSignOut: (e: React.MouseEvent) => void
   onSettingsClick: (
     e: React.MouseEvent,
-    section?: 'api-keys' | 'system-instructions' | 'temperatures' | 'models'
+    section?:
+      | 'api-keys'
+      | 'system-instructions'
+      | 'temperatures'
+      | 'models'
+      | 'generation'
   ) => void
 }
 
@@ -101,6 +106,26 @@ export const MenuItems: React.FC<MenuItemsProps> = ({
             strokeLinejoin="round"
             strokeWidth={2}
             d="M13 10V3L4 14h7v7l9-11h-7z"
+          />
+        </svg>
+      ),
+    },
+    {
+      section: 'generation' as const,
+      label: 'Generation',
+      description: 'Possibility defaults',
+      icon: (
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 6v6m0 0v6m0-6h6m-6 0H6"
           />
         </svg>
       ),

--- a/app/services/ai/PossibilityMetadataService.ts
+++ b/app/services/ai/PossibilityMetadataService.ts
@@ -102,7 +102,11 @@ export class PossibilityMetadataService {
           systemPrompt: permutation.systemPrompt,
           priority: this.calculatePriority(permutation, baseIndex),
           estimatedTokens:
-            options.maxTokens || getDefaultTokenLimit(permutation.model),
+            options.maxTokens ||
+            getDefaultTokenLimit(permutation.model, {
+              possibilityTokens: settings.possibilityTokens,
+              reasoningTokens: settings.reasoningTokens,
+            }),
           order: baseIndex * multiplier + instance,
         }
         allMetadata.push(metadata)

--- a/app/services/ai/config.ts
+++ b/app/services/ai/config.ts
@@ -313,8 +313,12 @@ export const isReasoningModel = (modelId: string): boolean => {
   return model?.isReasoningModel === true
 }
 
-export const getDefaultTokenLimit = (modelId: string): number => {
-  return isReasoningModel(modelId)
-    ? TOKEN_LIMITS.POSSIBILITY_REASONING
-    : TOKEN_LIMITS.POSSIBILITY_DEFAULT
+export const getDefaultTokenLimit = (
+  modelId: string,
+  settings?: { possibilityTokens?: number; reasoningTokens?: number }
+): number => {
+  if (isReasoningModel(modelId)) {
+    return settings?.reasoningTokens ?? TOKEN_LIMITS.POSSIBILITY_REASONING
+  }
+  return settings?.possibilityTokens ?? TOKEN_LIMITS.POSSIBILITY_DEFAULT
 }

--- a/app/types/settings.ts
+++ b/app/types/settings.ts
@@ -17,5 +17,10 @@ export interface UserSettings {
   temperatures?: Temperature[]
   enabledModels?: string[]
   possibilityMultiplier?: number // How many instances of each permutation to generate (default 1)
+  /** Generation default settings */
+  possibilityTokens?: number // Tokens for standard possibility generation
+  reasoningTokens?: number // Tokens when using reasoning models
+  continuationTokens?: number // Tokens for continued generation
+  maxInitialPossibilities?: number // How many possibilities load initially
   [key: string]: any // Allow for future settings
 }

--- a/app/utils/__tests__/cloudSettings.test.ts
+++ b/app/utils/__tests__/cloudSettings.test.ts
@@ -220,5 +220,51 @@ describe('CloudSettings', () => {
         })
       })
     })
+
+    describe('generation defaults', () => {
+      it('should return defaults when none saved', async () => {
+        mockFetch.mockResolvedValue(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+
+        const defaults = await CloudSettings.getGenerationDefaults()
+        expect(defaults).toEqual({
+          possibilityTokens: 100,
+          reasoningTokens: 1500,
+          continuationTokens: 1000,
+          maxInitialPossibilities: 12,
+        })
+      })
+
+      it('should update generation defaults', async () => {
+        mockFetch.mockResolvedValue(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        )
+
+        await CloudSettings.setGenerationDefaults({
+          possibilityTokens: 50,
+          reasoningTokens: 900,
+          continuationTokens: 800,
+          maxInitialPossibilities: 5,
+        })
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            possibilityTokens: 50,
+            reasoningTokens: 900,
+            continuationTokens: 800,
+            maxInitialPossibilities: 5,
+          }),
+        })
+      })
+    })
   })
 })

--- a/app/utils/cloudSettings.ts
+++ b/app/utils/cloudSettings.ts
@@ -1,5 +1,6 @@
 import { SystemInstruction, Temperature, UserSettings } from '../types/settings'
 import { DEFAULT_SYSTEM_INSTRUCTION } from '../constants/defaults'
+import { TOKEN_LIMITS } from '../services/ai/config'
 
 export type { SystemInstruction, Temperature, UserSettings }
 
@@ -111,6 +112,29 @@ export class CloudSettings {
 
   static async setEnabledModels(models: string[]): Promise<void> {
     await this.updateSettings({ enabledModels: models })
+  }
+
+  // Generation settings
+  static async getGenerationDefaults() {
+    const settings = await this.getSettings()
+    return {
+      possibilityTokens:
+        settings.possibilityTokens ?? TOKEN_LIMITS.POSSIBILITY_DEFAULT,
+      reasoningTokens:
+        settings.reasoningTokens ?? TOKEN_LIMITS.POSSIBILITY_REASONING,
+      continuationTokens:
+        settings.continuationTokens ?? TOKEN_LIMITS.CONTINUATION_DEFAULT,
+      maxInitialPossibilities: settings.maxInitialPossibilities ?? 12,
+    }
+  }
+
+  static async setGenerationDefaults(defaults: {
+    possibilityTokens: number
+    reasoningTokens: number
+    continuationTokens: number
+    maxInitialPossibilities: number
+  }): Promise<void> {
+    await this.updateSettings(defaults)
   }
 
   // Reset all settings to defaults


### PR DESCRIPTION
## Summary
- list all possibility generation defaults in README
- allow customizing possibility defaults from new Generation settings panel
- expose generation defaults via CloudSettings
- respect user-set maxInitialPossibilities when auto-loading
- use custom token limits in metadata generation
- support new `generation` settings section across menu and modals
- test CloudSettings generation convenience methods

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_686458d08f80832fbc4783e37533cdea