### PR TITLE
Fix npm ci typecheck failure

### DIFF
--- a/app/services/ai/PossibilityMetadataService.ts
+++ b/app/services/ai/PossibilityMetadataService.ts
@@ -146,6 +146,7 @@ export class PossibilityMetadataService {
   getTotalPossibilityCount(settings: UserSettings): number {
     // Convert UserSettings to the format expected by PermutationGenerator
     let enabledProviders: string[] = []
+    let enabledModels: string[] = []
 
     try {
       if (settings?.enabledProviders) {


### PR DESCRIPTION
## Summary
- ensure `enabledModels` is defined in `getTotalPossibilityCount`

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_b_6864c5d73510832f8b01f090c1840b4a