### PR TITLE
Prefix metadata title by environment

### DIFF
--- a/app/components/VirtualizedPossibilitiesPanel.tsx
+++ b/app/components/VirtualizedPossibilitiesPanel.tsx
@@ -75,9 +75,7 @@ const VirtualizedPossibilitiesPanel: React.FC<
       {isActive && (
         <div className="px-4 py-1 text-xs text-[#888] flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <span>
-              {possibilities.length} possibilities
-            </span>
+            <span>{possibilities.length} possibilities</span>
             <div className="flex items-center gap-2 text-[#666]">
               <span className="text-[#4ade80]">
                 ✓ {possibilities.filter((p) => p.isComplete).length}

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -1,7 +1,19 @@
 import type { Metadata } from 'next'
 
+const baseTitle = 'multichat - Multi-Model AI Chat Interface'
+
+const env = process.env.VERCEL_ENV
+let prefix = ''
+if (!env) {
+  prefix = '[local] '
+} else if (env === 'development') {
+  prefix = '[dev] '
+} else if (env === 'preview') {
+  prefix = '[preview] '
+}
+
 export const metadata: Metadata = {
-  title: 'multichat - Multi-Model AI Chat Interface',
+  title: `${prefix}${baseTitle}`,
   description:
     'A production-ready web application that shows multiple response possibilities from various AI models simultaneously.',
   keywords: [
@@ -21,14 +33,14 @@ export const metadata: Metadata = {
     type: 'website',
     locale: 'en_US',
     url: 'https://multichat.vercel.app',
-    title: 'multichat - Multi-Model AI Chat Interface',
+    title: `${prefix}${baseTitle}`,
     description:
       'A production-ready web application that shows multiple response possibilities from various AI models simultaneously.',
     siteName: 'multichat',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'multichat - Multi-Model AI Chat Interface',
+    title: `${prefix}${baseTitle}`,
     description:
       'A production-ready web application that shows multiple response possibilities from various AI models simultaneously.',
   },


### PR DESCRIPTION
## Summary
- prefix the site title with the Vercel environment
- fix formatting for VirtualizedPossibilitiesPanel

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6864d6956ba4832fbae383711a0a2d15