### PR TITLE
Add UI indicators for AI provider errors

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -119,6 +119,14 @@ const Message: React.FC<ExtendedMessageProps> = ({
             </div>
           )}
 
+          {/* Error message */}
+          {message.error && (
+            <div className="mt-2 text-xs text-red-400 flex items-center gap-1">
+              <span>⚠️</span>
+              <span>{message.error}</span>
+            </div>
+          )}
+
           {/* Possibilities Panel */}
           {!isUser &&
             message.possibilities &&

--- a/app/components/VirtualizedPossibilitiesPanel.tsx
+++ b/app/components/VirtualizedPossibilitiesPanel.tsx
@@ -124,6 +124,7 @@ const VirtualizedPossibilitiesPanel: React.FC<
                   systemInstruction:
                     possibility.metadata.systemInstruction?.name,
                   isPossibility: true,
+                  error: possibility.error || undefined,
                 }
 
                 return (

--- a/app/components/__tests__/Message.test.tsx
+++ b/app/components/__tests__/Message.test.tsx
@@ -207,6 +207,17 @@ describe('Message', () => {
     }).not.toThrow()
   })
 
+  it('displays error message when provided', () => {
+    const message = createMockMessage({
+      role: 'assistant',
+      error: 'Invalid API key',
+    })
+
+    render(<Message message={message} />)
+
+    expect(screen.getByText('Invalid API key')).toBeInTheDocument()
+  })
+
   it('displays correct avatar for different models', () => {
     const models = ['gpt-4', 'claude-3', 'gemini-pro']
 

--- a/app/hooks/useSimplePossibilities.ts
+++ b/app/hooks/useSimplePossibilities.ts
@@ -18,6 +18,7 @@ interface PossibilityState {
   isComplete: boolean
   metadata: PossibilityMetadata
   probability: number | null
+  error: string | null
 }
 
 export function useSimplePossibilities(
@@ -94,6 +95,7 @@ export function useSimplePossibilities(
           isComplete: false,
           metadata: meta,
           probability: null,
+          error: null,
         },
       ])
 
@@ -159,6 +161,19 @@ export function useSimplePossibilities(
                         : p
                     )
                   )
+                } else if (event.type === 'error') {
+                  // Mark as failed with short message
+                  setPossibilities((prev) =>
+                    prev.map((p) =>
+                      p.id === possibilityId
+                        ? {
+                            ...p,
+                            isComplete: true,
+                            error: event.data.message || 'Error',
+                          }
+                        : p
+                    )
+                  )
                 }
               }
             }
@@ -176,9 +191,21 @@ export function useSimplePossibilities(
             loadingRef.current.delete(possibilityId)
           } else {
             console.error(`Error loading possibility ${possibilityId}:`, error)
+            setPossibilities((prev) =>
+              prev.map((p) =>
+                p.id === possibilityId
+                  ? {
+                      ...p,
+                      isComplete: true,
+                      error:
+                        error instanceof Error
+                          ? error.message
+                          : 'Unknown error',
+                    }
+                  : p
+              )
+            )
           }
-          // Remove from possibilities on error
-          setPossibilities((prev) => prev.filter((p) => p.id !== possibilityId))
         } finally {
           activeConnections--
           abortControllersRef.current.delete(possibilityId)

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -19,6 +19,7 @@ export interface Message {
   possibilities?: Message[] // Alternative responses for assistant messages
   isPossibility?: boolean // True if this is a possibility that can be selected
   systemInstruction?: string // Name of the system instruction used
+  error?: string // Short error message when generation fails
 }
 
 export interface ChatContainerProps {


### PR DESCRIPTION
## Summary
- add `error` field to `Message` type
- track AI provider errors in `useSimplePossibilities`
- surface errors in `VirtualizedPossibilitiesPanel`
- display short error text in `Message` component
- test error display in message component

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686588abc880832fb86eb7007ef86293