### PR TITLE
Fix provider lookup errors

### DIFF
--- a/app/components/Message.tsx
+++ b/app/components/Message.tsx
@@ -49,7 +49,7 @@ const Message: React.FC<ExtendedMessageProps> = ({
           ) : (
             <Image
               src={getProviderLogo(
-                getProviderFromModel(message.model || 'openai'),
+                message.model ? getProviderFromModel(message.model) : 'openai',
                 'light'
               )}
               alt="AI"
@@ -161,9 +161,9 @@ const Message: React.FC<ExtendedMessageProps> = ({
                           <div className="flex items-center gap-1 shrink-0 w-[16px]">
                             <Image
                               src={getProviderLogo(
-                                getProviderFromModel(
-                                  possibility.model || 'openai'
-                                ),
+                                possibility.model
+                                  ? getProviderFromModel(possibility.model)
+                                  : 'openai',
                                 'dark'
                               )}
                               alt="Provider"

--- a/app/components/MessageWithIndependentPossibilities.tsx
+++ b/app/components/MessageWithIndependentPossibilities.tsx
@@ -99,7 +99,9 @@ const MessageWithIndependentPossibilities: React.FC<
             <Image
               src={getProviderLogo(
                 typeof message.model === 'string'
-                  ? getProviderFromModel(message.model || 'openai')
+                  ? message.model
+                    ? getProviderFromModel(message.model)
+                    : 'openai'
                   : (message.model as any)?.provider || 'openai',
                 'light'
               )}

--- a/app/components/SystemInstructionsPanel.tsx
+++ b/app/components/SystemInstructionsPanel.tsx
@@ -40,7 +40,9 @@ const SystemInstructionsPanel: React.FC = () => {
   }
 
   const handleAddSystemInstruction = async (name: string, content: string) => {
-    if (systemInstructions.length >= SYSTEM_INSTRUCTION_LIMITS.MAX_INSTRUCTIONS) {
+    if (
+      systemInstructions.length >= SYSTEM_INSTRUCTION_LIMITS.MAX_INSTRUCTIONS
+    ) {
       throw new Error(
         `Maximum of ${SYSTEM_INSTRUCTION_LIMITS.MAX_INSTRUCTIONS} system instructions allowed`
       )
@@ -142,7 +144,8 @@ const SystemInstructionsPanel: React.FC = () => {
           System Instructions ({systemInstructions.length}/
           {SYSTEM_INSTRUCTION_LIMITS.MAX_INSTRUCTIONS})
         </h3>
-        {systemInstructions.length < SYSTEM_INSTRUCTION_LIMITS.MAX_INSTRUCTIONS &&
+        {systemInstructions.length <
+          SYSTEM_INSTRUCTION_LIMITS.MAX_INSTRUCTIONS &&
           !showAddForm &&
           !editingInstruction && (
             <button

--- a/app/components/__tests__/Message.possibilities.test.tsx
+++ b/app/components/__tests__/Message.possibilities.test.tsx
@@ -52,8 +52,13 @@ describe('Message - Possibilities', () => {
 
   it('renders possibilities panel when possibilities exist', () => {
     const possibilities = [
-      createMockPossibility('p1', 'Alternative response 1', 'claude-3', 0.75),
-      createMockPossibility('p2', 'Alternative response 2', 'gpt-3.5', 0.65),
+      createMockPossibility(
+        'p1',
+        'Alternative response 1',
+        'claude-3-opus-20240229',
+        0.75
+      ),
+      createMockPossibility('p2', 'Alternative response 2', 'gpt-4o', 0.65),
     ]
 
     const message = createMockMessage({ possibilities })
@@ -72,7 +77,12 @@ describe('Message - Possibilities', () => {
 
   it('displays possibility metadata correctly', () => {
     const possibilities = [
-      createMockPossibility('p1', 'Alternative response', 'claude-3', 0.75),
+      createMockPossibility(
+        'p1',
+        'Alternative response',
+        'claude-3-opus-20240229',
+        0.75
+      ),
     ]
 
     const message = createMockMessage({ possibilities })
@@ -83,7 +93,7 @@ describe('Message - Possibilities', () => {
       />
     )
 
-    expect(screen.getByText('c-3')).toBeInTheDocument()
+    expect(screen.getByText('c-3-opus')).toBeInTheDocument()
     expect(screen.getByText('P:75%')).toBeInTheDocument()
   })
 
@@ -91,7 +101,7 @@ describe('Message - Possibilities', () => {
     const possibility = createMockPossibility(
       'p1',
       'Alternative response',
-      'claude-3',
+      'claude-3-opus-20240229',
       0.75
     )
     const possibilities = [possibility]
@@ -112,9 +122,14 @@ describe('Message - Possibilities', () => {
 
   it('renders multiple possibilities with correct styling', () => {
     const possibilities = [
-      createMockPossibility('p1', 'First alternative', 'claude-3', 0.75),
-      createMockPossibility('p2', 'Second alternative', 'gpt-3.5', 0.65),
-      createMockPossibility('p3', 'Third alternative', 'gemini', 0.55),
+      createMockPossibility(
+        'p1',
+        'First alternative',
+        'claude-3-opus-20240229',
+        0.75
+      ),
+      createMockPossibility('p2', 'Second alternative', 'gpt-4o', 0.65),
+      createMockPossibility('p3', 'Third alternative', 'gemini-1.5-pro', 0.55),
     ]
 
     const message = createMockMessage({ possibilities })
@@ -147,7 +162,12 @@ describe('Message - Possibilities', () => {
 
   it('applies hover styles to possibilities', () => {
     const possibilities = [
-      createMockPossibility('p1', 'Alternative response', 'claude-3', 0.75),
+      createMockPossibility(
+        'p1',
+        'Alternative response',
+        'claude-3-opus-20240229',
+        0.75
+      ),
     ]
 
     const message = createMockMessage({ possibilities })
@@ -184,7 +204,12 @@ describe('Message - Possibilities', () => {
 
   it('does not render possibilities panel for user messages', () => {
     const possibilities = [
-      createMockPossibility('p1', 'Alternative response', 'claude-3', 0.75),
+      createMockPossibility(
+        'p1',
+        'Alternative response',
+        'claude-3-opus-20240229',
+        0.75
+      ),
     ]
 
     const message = createMockMessage({
@@ -219,7 +244,12 @@ describe('Message - Possibilities', () => {
 
   it('works without onSelectPossibility callback', () => {
     const possibilities = [
-      createMockPossibility('p1', 'Alternative response', 'claude-3', 0.75),
+      createMockPossibility(
+        'p1',
+        'Alternative response',
+        'claude-3-opus-20240229',
+        0.75
+      ),
     ]
 
     const message = createMockMessage({ possibilities })

--- a/app/components/__tests__/Message.test.tsx
+++ b/app/components/__tests__/Message.test.tsx
@@ -89,12 +89,12 @@ describe('Message', () => {
   it('displays model name for assistant messages', () => {
     const message = createMockMessage({
       role: 'assistant',
-      model: 'claude-3',
+      model: 'claude-3-opus-20240229',
     })
 
     render(<Message message={message} />)
 
-    expect(screen.getByText('claude-3')).toBeInTheDocument()
+    expect(screen.getByText('claude-3-opus-20240229')).toBeInTheDocument()
     expect(screen.getByAltText('AI')).toBeInTheDocument() // OpenAI logo avatar
   })
 
@@ -208,7 +208,7 @@ describe('Message', () => {
   })
 
   it('displays correct avatar for different models', () => {
-    const models = ['gpt-4', 'claude-3', 'gemini-pro']
+    const models = ['gpt-4', 'claude-3-opus-20240229', 'gemini-1.5-pro']
 
     models.forEach((model) => {
       const message = createMockMessage({

--- a/app/components/__tests__/SystemInstructionsPanel.test.tsx
+++ b/app/components/__tests__/SystemInstructionsPanel.test.tsx
@@ -232,7 +232,12 @@ describe('SystemInstructionsPanel', () => {
     it('hides add button when limit reached', async () => {
       const many = Array.from(
         { length: SYSTEM_INSTRUCTION_LIMITS.MAX_INSTRUCTIONS },
-        (_, i) => ({ id: `${i}`, name: `inst${i}`, content: 'c', enabled: true })
+        (_, i) => ({
+          id: `${i}`,
+          name: `inst${i}`,
+          content: 'c',
+          enabled: true,
+        })
       )
       mockCloudSettings.getSystemInstructions.mockResolvedValueOnce(many)
 

--- a/app/hooks/useSimplePossibilities.ts
+++ b/app/hooks/useSimplePossibilities.ts
@@ -199,7 +199,7 @@ export function useSimplePossibilities(
         connectionQueue.push(executeRequest)
       }
     },
-    [messages, metadata]
+    [messages, metadata, settings.possibilityTokens, settings.reasoningTokens]
   )
 
   return {

--- a/app/utils/providerLogos.ts
+++ b/app/utils/providerLogos.ts
@@ -4,6 +4,7 @@ import anthropicLogo from '../assets/anthropic.png'
 import geminiLogo from '../assets/gemini.svg'
 import mistralLogo from '../assets/mistral.png'
 import huggingfaceLogo from '../assets/huggingface.svg'
+import { getModelById } from '../services/ai/config'
 
 export const providerLogos = {
   openai: {
@@ -34,28 +35,16 @@ export function getProviderLogo(
 ) {
   const logos = providerLogos[provider as keyof typeof providerLogos]
   if (!logos) {
-    // Default to OpenAI if provider not found
-    return providerLogos.openai[theme]
+    throw new Error(`Provider not found: ${provider}`)
   }
   return logos[theme]
 }
 
-export function getProviderFromModel(model: string): string {
-  // Extract provider from model ID
-  if (model.includes('gpt') || model.includes('openai')) {
-    return 'openai'
-  } else if (model.includes('claude') || model.includes('anthropic')) {
-    return 'anthropic'
-  } else if (model.includes('gemini') || model.includes('google')) {
-    return 'google'
-  } else if (model.includes('mistral')) {
-    return 'mistral'
-  } else if (
-    model.includes('meta') ||
-    model.includes('llama') ||
-    model.includes('together')
-  ) {
-    return 'together'
+export function getProviderFromModel(modelId: string): string {
+  const normalizedId = modelId.toLowerCase()
+  const model = getModelById(modelId) || getModelById(normalizedId)
+  if (!model) {
+    throw new Error(`Model not found: ${modelId}`)
   }
-  return 'openai' // default
+  return model.provider
 }


### PR DESCRIPTION
## Summary
- throw an error when provider logo isn't found
- normalize model IDs for provider lookup
- fix lint and format warnings

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68658130ea1c832fafda7694c674adbc