### PR TITLE
Add conversation sharing via Vercel Blob

### DIFF
--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { log } from '@/services/LoggingService'
+import { getServerLogContext } from '../../../lib/logging'
+import { getConversation } from '@/services/BlobConversationService'
+
+export async function GET(_request: NextRequest, context: any) {
+  const { id } = context.params as { id: string }
+  try {
+    const conversation = await getConversation(id)
+    if (!conversation) {
+      const ctx = await getServerLogContext()
+      log.warn(`Conversation not found: ${id}`, ctx)
+      return NextResponse.json(null)
+    }
+    return NextResponse.json({ conversation })
+  } catch (error) {
+    const ctx = await getServerLogContext()
+    log.error('Failed to load conversation', error as Error, ctx)
+    return NextResponse.json(
+      { error: 'Failed to load conversation' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../lib/auth'
+import { log } from '@/services/LoggingService'
+import { getServerLogContext } from '../../lib/logging'
+import { saveConversation } from '@/services/BlobConversationService'
+import { z } from 'zod'
+import type { Message } from '@/types/chat'
+
+const messageSchema = z.object({
+  id: z.string(),
+  role: z.enum(['user', 'assistant']),
+  content: z.string().nullable().optional(),
+  model: z.string().optional(),
+  probability: z.number().nullable().optional(),
+  temperature: z.number().optional(),
+  timestamp: z.string(),
+  possibilities: z.array(z.any()).optional(),
+  systemInstruction: z.string().optional(),
+  isPossibility: z.boolean().optional(),
+  attachments: z.any().optional(),
+  error: z.string().optional(),
+})
+
+const bodySchema = z.object({
+  messages: z.array(messageSchema),
+})
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const body = bodySchema.parse(await request.json())
+    const msgs = body.messages.map((m) => ({
+      ...m,
+      timestamp: new Date(m.timestamp),
+    })) as Message[]
+    const id = await saveConversation(session.user.id, msgs)
+    return NextResponse.json({ id })
+  } catch (error) {
+    const context = await getServerLogContext()
+    log.error('Failed to save conversation', error as Error, context)
+    return NextResponse.json(
+      { error: 'Failed to save conversation' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/components/ChatContainer.tsx
+++ b/app/components/ChatContainer.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import type { ChatContainerProps, Message as MessageType } from '../types/chat'
@@ -20,6 +21,10 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
   className = '',
   settingsLoading = false,
   apiKeysLoading = false,
+  onPublish,
+  publishDisabled = false,
+  showCopied = false,
+  onTitleClick,
 }) => {
   // Settings modal state
   const [showSettings, setShowSettings] = useState(false)
@@ -57,7 +62,13 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
 
   return (
     <div className={`flex flex-col h-full bg-[#0a0a0a] ${className}`}>
-      <ChatHeader onOpenSettings={handleOpenSettings} />
+      <ChatHeader
+        onOpenSettings={handleOpenSettings}
+        onPublish={onPublish}
+        publishDisabled={publishDisabled}
+        showCopied={showCopied}
+        onTitleClick={onTitleClick}
+      />
 
       <AuthenticationBanner
         disabled={disabled}

--- a/app/components/chat/ChatHeader.tsx
+++ b/app/components/chat/ChatHeader.tsx
@@ -17,15 +17,59 @@ export interface ChatHeaderProps {
       | 'models'
       | 'generation'
   ) => void
+  onPublish?: () => void
+  publishDisabled?: boolean
+  showCopied?: boolean
+  onTitleClick?: () => void
 }
 
-export const ChatHeader: React.FC<ChatHeaderProps> = ({ onOpenSettings }) => {
+export const ChatHeader: React.FC<ChatHeaderProps> = ({
+  onOpenSettings,
+  onPublish,
+  publishDisabled = false,
+  showCopied = false,
+  onTitleClick,
+}) => {
   return (
     <div className="flex items-center justify-between p-4 bg-[#1a1a1a] border-b border-[#2a2a2a] min-h-[56px]">
-      <div className="text-lg font-bold bg-gradient-to-r from-[#667eea] to-[#764ba2] bg-clip-text text-transparent">
+      <div
+        className="text-lg font-bold bg-gradient-to-r from-[#667eea] to-[#764ba2] bg-clip-text text-transparent cursor-pointer"
+        onClick={onTitleClick}
+      >
         chatsbox.ai
       </div>
-      <Menu onOpenSettings={onOpenSettings} />
+      <div className="flex items-center gap-3">
+        {onPublish && (
+          <div className="relative">
+            <button
+              onClick={onPublish}
+              disabled={publishDisabled}
+              className="flex-shrink-0 p-2 bg-gradient-to-r from-[#667eea] to-[#764ba2] text-white rounded-md hover:translate-y-[-2px] hover:shadow-[0_4px_20px_rgba(102,126,234,0.3)] disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+              aria-label="Publish conversation"
+            >
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 5l7 7m0 0l-7 7m7-7H6"
+                />
+              </svg>
+            </button>
+            {showCopied && (
+              <span className="absolute -top-2 -right-2 text-xs animate-fadeInOut">
+                Copied
+              </span>
+            )}
+          </div>
+        )}
+        <Menu onOpenSettings={onOpenSettings} />
+      </div>
     </div>
   )
 }

--- a/app/components/chat/__tests__/ChatHeader.test.tsx
+++ b/app/components/chat/__tests__/ChatHeader.test.tsx
@@ -67,4 +67,46 @@ describe('ChatHeader', () => {
 
     expect(screen.getByTestId('menu-button')).toBeInTheDocument()
   })
+
+  it('calls onPublish when publish button clicked', async () => {
+    const mockOnOpenSettings = vi.fn()
+    const mockPublish = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        onPublish={mockPublish}
+        publishDisabled={false}
+      />
+    )
+
+    const button = screen.getByLabelText('Publish conversation')
+    await user.click(button)
+    expect(mockPublish).toHaveBeenCalled()
+  })
+
+  it('shows copied indicator when showCopied true', () => {
+    const mockOnOpenSettings = vi.fn()
+
+    render(
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        onPublish={vi.fn()}
+        showCopied
+      />
+    )
+
+    expect(screen.getByText('Copied')).toBeInTheDocument()
+  })
+
+  it('triggers onTitleClick when title clicked', async () => {
+    const mockTitle = vi.fn()
+    const user = userEvent.setup()
+
+    render(<ChatHeader onOpenSettings={vi.fn()} onTitleClick={mockTitle} />)
+
+    await user.click(screen.getByText('chatsbox.ai'))
+    expect(mockTitle).toHaveBeenCalled()
+  })
 })

--- a/app/conversation/[id]/page.tsx
+++ b/app/conversation/[id]/page.tsx
@@ -1,0 +1,26 @@
+import ChatDemo from '@/components/ChatDemo'
+import ChatContainer from '@/components/ChatContainer'
+import { getConversation } from '@/services/BlobConversationService'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+
+export default async function ConversationPage({ params }: any) {
+  const conversation = await getConversation(params.id)
+  if (!conversation) {
+    return <div className="p-4">Conversation not found.</div>
+  }
+
+  const session = await getServerSession(authOptions)
+  if (session?.user) {
+    return <ChatDemo initialMessages={conversation.messages} />
+  }
+
+  return (
+    <ChatContainer
+      messages={conversation.messages}
+      onSendMessage={() => {}}
+      disabled
+      className="h-[100dvh]"
+    />
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -126,3 +126,22 @@ code {
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
   background: #3a3a3a;
 }
+
+@keyframes fadeInOut {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.animate-fadeInOut {
+  animation: fadeInOut 1.5s forwards;
+}

--- a/app/services/BlobConversationService.ts
+++ b/app/services/BlobConversationService.ts
@@ -1,0 +1,67 @@
+import { put, head, BlobNotFoundError } from '@vercel/blob'
+import { randomUUID } from 'crypto'
+import type { Message } from '@/types/chat'
+import { log } from './LoggingService'
+
+export interface ConversationRecord {
+  id: string
+  userId: string
+  messages: Message[]
+  timestamp: string
+}
+
+const BASE_PATH = 'conversations'
+
+async function generateUniqueId(): Promise<string> {
+  while (true) {
+    const id = randomUUID()
+    try {
+      await head(`${BASE_PATH}/${id}.json`)
+      // Collision - try again
+    } catch (error) {
+      if (error instanceof BlobNotFoundError) {
+        return id
+      }
+    }
+  }
+}
+
+export async function saveConversation(
+  userId: string,
+  messages: Message[]
+): Promise<string> {
+  const id = await generateUniqueId()
+  const record: ConversationRecord = {
+    id,
+    userId,
+    messages,
+    timestamp: new Date().toISOString(),
+  }
+  try {
+    await put(`${BASE_PATH}/${id}.json`, JSON.stringify(record), {
+      access: 'public',
+    })
+    return id
+  } catch (error) {
+    log.error('Failed to save conversation', error as Error, { userId })
+    throw error
+  }
+}
+
+export async function getConversation(
+  id: string
+): Promise<ConversationRecord | null> {
+  try {
+    const res = await fetch(`${BASE_PATH}/${id}.json`)
+    if (!res.ok) throw new BlobNotFoundError()
+    const text = await res.text()
+    return JSON.parse(text) as ConversationRecord
+  } catch (error) {
+    if (error instanceof BlobNotFoundError) {
+      log.warn(`Conversation not found: ${id}`)
+      return null
+    }
+    log.error(`Failed to load conversation ${id}`, error as Error)
+    return null
+  }
+}

--- a/app/services/__tests__/BlobConversationService.test.ts
+++ b/app/services/__tests__/BlobConversationService.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { saveConversation, getConversation } from '../BlobConversationService'
+import { BlobNotFoundError } from '@vercel/blob'
+import { randomUUID } from 'crypto'
+
+var putMock: any
+var headMock: any
+vi.mock('@vercel/blob', () => {
+  putMock = vi.fn()
+  headMock = vi.fn()
+  return {
+    put: putMock,
+    head: headMock,
+    BlobNotFoundError: class BlobNotFoundError extends Error {},
+  }
+})
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+vi.mock('crypto', async () => {
+  const actual = await vi.importActual<typeof import('crypto')>('crypto')
+  return { ...actual, randomUUID: vi.fn(() => 'uuid-1') }
+})
+
+describe('BlobConversationService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves conversation and returns id', async () => {
+    headMock.mockRejectedValue(new (BlobNotFoundError as any)())
+    putMock.mockResolvedValue({} as any)
+
+    const id = await saveConversation('user', [])
+    expect(typeof id).toBe('string')
+    expect(putMock).toHaveBeenCalled()
+  })
+
+  it('returns null when conversation missing', async () => {
+    fetchMock.mockResolvedValue({ ok: false } as any)
+    const conv = await getConversation('missing')
+    expect(conv).toBeNull()
+  })
+})

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -35,6 +35,10 @@ export interface ChatContainerProps {
   className?: string
   settingsLoading?: boolean
   apiKeysLoading?: boolean
+  onPublish?: () => void
+  publishDisabled?: boolean
+  showCopied?: boolean
+  onTitleClick?: () => void
 }
 
 export interface MessageProps {


### PR DESCRIPTION
## Summary
- implement `BlobConversationService` for Vercel Blob persistence
- add API routes for saving and retrieving conversations
- enable conversation viewing page
- add publish button in `ChatHeader` and related props
- support initial messages & publishing in `ChatDemo`
- update styles with fade animation and tests
- add new service tests

## Testing
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_b_686836fb0e3c832fbe39371aa0ebefd3