### PR TITLE
Add conversation sharing via blob

### DIFF
--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getConversation } from '../../../services/blob/conversations'
+import { log } from '@/services/LoggingService'
+import { getServerLogContext } from '../../../lib/logging'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } } | any
+) {
+  try {
+    const conversation = await getConversation(params.id)
+    if (!conversation) {
+      const context = await getServerLogContext()
+      log.info(`Conversation not found: ${params.id}`, context)
+      return NextResponse.json(null, { status: 404 })
+    }
+    return NextResponse.json(conversation)
+  } catch (error) {
+    const context = await getServerLogContext()
+    log.error('Failed to load conversation', error as Error, context)
+    return NextResponse.json(
+      { error: 'Failed to load conversation' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/conversations/__tests__/route.test.ts
+++ b/app/api/conversations/__tests__/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '../route'
+import { GET } from '../[id]/route'
+import { getServerSession } from 'next-auth'
+import * as blobService from '../../../services/blob/conversations'
+
+const createUrl = (path: string) => {
+  const base = process.env.NEXTAUTH_URL || 'http://localhost:3000'
+  return `${base}${path}`
+}
+
+vi.mock('next-auth')
+vi.mock('../../../services/blob/conversations')
+
+describe('/api/conversations', () => {
+  const mockSession = { user: { id: 'user1' } }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('POST', () => {
+    it('returns 401 when not authenticated', async () => {
+      vi.mocked(getServerSession).mockResolvedValue(null)
+      const req = new NextRequest(createUrl('/api/conversations'), {
+        method: 'POST',
+      })
+      const res = await POST(req)
+      expect(res.status).toBe(401)
+    })
+
+    it('saves conversation and returns id', async () => {
+      vi.mocked(getServerSession).mockResolvedValue(mockSession)
+      vi.mocked(blobService.saveConversation).mockResolvedValue('abc')
+      const req = new NextRequest(createUrl('/api/conversations'), {
+        method: 'POST',
+        body: JSON.stringify({
+          messages: [
+            {
+              id: '1',
+              role: 'user',
+              content: 'hi',
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+        }),
+      })
+      const res = await POST(req)
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.id).toBe('abc')
+    })
+  })
+
+  describe('GET', () => {
+    it('returns 404 when not found', async () => {
+      vi.mocked(blobService.getConversation).mockResolvedValue(null)
+      const req = new NextRequest(createUrl('/api/conversations/none'))
+      const res = await GET(req, { params: { id: 'none' } })
+      expect(res.status).toBe(404)
+    })
+
+    it('returns conversation when exists', async () => {
+      vi.mocked(blobService.getConversation).mockResolvedValue({
+        id: 'x',
+        userId: 'u',
+        messages: [],
+        timestamp: new Date(),
+      })
+      const req = new NextRequest(createUrl('/api/conversations/x'))
+      const res = await GET(req, { params: { id: 'x' } })
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.id).toBe('x')
+    })
+  })
+})

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../lib/auth'
+import { saveConversation } from '../../services/blob/conversations'
+import { log } from '@/services/LoggingService'
+import { getServerLogContext } from '../../lib/logging'
+import type { Message } from '../../types/chat'
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const { messages } = (await request.json()) as { messages: Message[] }
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json(
+        { error: 'Invalid conversation' },
+        { status: 400 }
+      )
+    }
+    const id = await saveConversation({
+      userId: session.user.id,
+      messages,
+      timestamp: new Date(),
+    })
+    return NextResponse.json({ id })
+  } catch (error) {
+    const context = await getServerLogContext()
+    log.error('Failed to save conversation', error as Error, context)
+    return NextResponse.json(
+      { error: 'Failed to save conversation' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/components/ChatContainer.tsx
+++ b/app/components/ChatContainer.tsx
@@ -15,6 +15,8 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
   onSendMessage,
   onSelectPossibility,
   onContinuePossibility,
+  onPublishConversation,
+  publishDisabled = false,
   isLoading = false,
   disabled = false,
   className = '',
@@ -57,7 +59,11 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
 
   return (
     <div className={`flex flex-col h-full bg-[#0a0a0a] ${className}`}>
-      <ChatHeader onOpenSettings={handleOpenSettings} />
+      <ChatHeader
+        onOpenSettings={handleOpenSettings}
+        onPublish={onPublishConversation}
+        publishDisabled={publishDisabled}
+      />
 
       <AuthenticationBanner
         disabled={disabled}

--- a/app/components/chat/ChatHeader.tsx
+++ b/app/components/chat/ChatHeader.tsx
@@ -6,6 +6,7 @@
  */
 
 import React from 'react'
+import Link from 'next/link'
 import Menu from '../Menu'
 
 export interface ChatHeaderProps {
@@ -17,15 +18,65 @@ export interface ChatHeaderProps {
       | 'models'
       | 'generation'
   ) => void
+  onPublish?: () => void
+  publishDisabled?: boolean
 }
 
-export const ChatHeader: React.FC<ChatHeaderProps> = ({ onOpenSettings }) => {
+export const ChatHeader: React.FC<ChatHeaderProps> = ({
+  onOpenSettings,
+  onPublish,
+  publishDisabled = false,
+}) => {
+  const [showCopy, setShowCopy] = React.useState(false)
+
+  const handlePublish = async () => {
+    if (!onPublish) return
+    await onPublish()
+    setShowCopy(true)
+    setTimeout(() => setShowCopy(false), 2000)
+  }
+
   return (
     <div className="flex items-center justify-between p-4 bg-[#1a1a1a] border-b border-[#2a2a2a] min-h-[56px]">
-      <div className="text-lg font-bold bg-gradient-to-r from-[#667eea] to-[#764ba2] bg-clip-text text-transparent">
+      <Link
+        href="/"
+        className="text-lg font-bold bg-gradient-to-r from-[#667eea] to-[#764ba2] bg-clip-text text-transparent"
+      >
         chatsbox.ai
+      </Link>
+      <div className="flex items-center gap-2">
+        {onPublish && (
+          <button
+            type="button"
+            onClick={handlePublish}
+            disabled={publishDisabled}
+            aria-label="Publish conversation"
+            className="p-2 bg-gradient-to-r from-[#667eea] to-[#764ba2] text-white rounded-md hover:translate-y-[-2px] hover:shadow-[0_4px_20px_rgba(102,126,234,0.3)] disabled:opacity-50 disabled:cursor-not-allowed transition-all disabled:hover:transform-none disabled:hover:shadow-none"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 4v6a2 2 0 002 2h6"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M14 10l6-6m0 0H10m10 0v10"
+              />
+            </svg>
+          </button>
+        )}
+        {showCopy && <span className="text-xs animate-fadeInOut">Copied!</span>}
+        <Menu onOpenSettings={onOpenSettings} />
       </div>
-      <Menu onOpenSettings={onOpenSettings} />
     </div>
   )
 }

--- a/app/components/chat/__tests__/ChatHeader.test.tsx
+++ b/app/components/chat/__tests__/ChatHeader.test.tsx
@@ -67,4 +67,46 @@ describe('ChatHeader', () => {
 
     expect(screen.getByTestId('menu-button')).toBeInTheDocument()
   })
+
+  it('calls onPublish when publish button clicked', async () => {
+    const mockOnOpenSettings = vi.fn()
+    const mockOnPublish = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        onPublish={mockOnPublish}
+      />
+    )
+
+    const publishButton = screen.getByLabelText('Publish conversation')
+    await user.click(publishButton)
+    expect(mockOnPublish).toHaveBeenCalled()
+  })
+
+  it('disables publish button when publishDisabled is true', () => {
+    const mockOnOpenSettings = vi.fn()
+
+    render(
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        onPublish={vi.fn()}
+        publishDisabled
+      />
+    )
+
+    const publishButton = screen.getByLabelText('Publish conversation')
+    expect(publishButton).toBeDisabled()
+  })
+
+  it('title links to home page', () => {
+    const mockOnOpenSettings = vi.fn()
+
+    render(<ChatHeader onOpenSettings={mockOnOpenSettings} />)
+
+    const link = screen.getByText('chatsbox.ai') as HTMLAnchorElement
+    expect(link.tagName).toBe('A')
+    expect(link.getAttribute('href')).toBe('/')
+  })
 })

--- a/app/conversation/[id]/page.tsx
+++ b/app/conversation/[id]/page.tsx
@@ -1,0 +1,25 @@
+import ChatDemo from '../../components/ChatDemo'
+import type { Message } from '../../types/chat'
+import { notFound } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+
+export default async function ConversationPage({
+  params,
+}:
+  | {
+      params: { id: string }
+    }
+  | any) {
+  const res = await fetch(
+    `${process.env.NEXTAUTH_URL || ''}/api/conversations/${params.id}`,
+    { cache: 'no-store' }
+  )
+  if (!res.ok) {
+    return notFound()
+  }
+  const data = await res.json()
+  if (!data) return notFound()
+  const messages: Message[] = data.messages
+  return <ChatDemo initialMessages={messages} />
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -126,3 +126,22 @@ code {
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
   background: #3a3a3a;
 }
+
+@keyframes fadeInOut {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.animate-fadeInOut {
+  animation: fadeInOut 2s forwards;
+}

--- a/app/services/__tests__/ConversationService.test.ts
+++ b/app/services/__tests__/ConversationService.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { saveConversation, getConversation } from '../blob/conversations'
+import type { Message } from '../../types/chat'
+
+vi.mock('@vercel/blob', () => ({
+  head: vi.fn(),
+  put: vi.fn(),
+  BlobNotFoundError: class extends Error {
+    name = 'BlobNotFoundError'
+  },
+}))
+
+const { head, put } = await import('@vercel/blob')
+
+describe('Conversation Blob Service', () => {
+  const messages: Message[] = [
+    {
+      id: '1',
+      role: 'user',
+      content: 'hi',
+      timestamp: new Date('2024-01-01T00:00:00Z'),
+    },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('saves conversation and returns id', async () => {
+    vi.mocked(head).mockRejectedValue({ name: 'BlobNotFoundError' })
+    vi.mocked(put).mockResolvedValue({
+      pathname: 'conversations/id.json',
+    } as any)
+    const id = await saveConversation({
+      userId: 'u1',
+      messages,
+      timestamp: new Date('2024-01-01T00:00:00Z'),
+    })
+    expect(put).toHaveBeenCalled()
+    expect(typeof id).toBe('string')
+  })
+
+  it('returns null when conversation not found', async () => {
+    vi.mocked(head).mockRejectedValue({ name: 'BlobNotFoundError' })
+    const convo = await getConversation('missing')
+    expect(convo).toBeNull()
+  })
+
+  it('retrieves conversation when exists', async () => {
+    vi.mocked(head).mockResolvedValue({
+      url: 'https://store/conversations/id.json',
+    } as any)
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'id',
+          userId: 'u1',
+          messages,
+          timestamp: '2024-01-01T00:00:00Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    vi.stubGlobal('fetch', mockFetch)
+    const convo = await getConversation('id')
+    expect(convo?.id).toBe('id')
+    expect(mockFetch).toHaveBeenCalled()
+  })
+})

--- a/app/services/blob/conversations.ts
+++ b/app/services/blob/conversations.ts
@@ -1,0 +1,58 @@
+import { put, head, BlobNotFoundError } from '@vercel/blob'
+import { randomUUID } from 'crypto'
+import type { Conversation } from '../../types/conversation'
+import { log } from '../LoggingService'
+
+const PREFIX = 'conversations'
+
+async function generateId(): Promise<string> {
+  while (true) {
+    const id = randomUUID()
+    try {
+      await head(`${PREFIX}/${id}.json`)
+    } catch (err: any) {
+      if (
+        err instanceof BlobNotFoundError ||
+        err?.name === 'BlobNotFoundError'
+      ) {
+        return id
+      }
+      log.error('Blob head error', err as Error)
+      throw err
+    }
+  }
+}
+
+export async function saveConversation(
+  data: Omit<Conversation, 'id'>
+): Promise<string> {
+  const id = await generateId()
+  const conversation: Conversation = { ...data, id }
+  try {
+    await put(`${PREFIX}/${id}.json`, JSON.stringify(conversation), {
+      access: 'public',
+    })
+  } catch (error) {
+    log.error('Failed to save conversation', error as Error)
+    throw error
+  }
+  return id
+}
+
+export async function getConversation(
+  id: string
+): Promise<Conversation | null> {
+  try {
+    const meta = await head(`${PREFIX}/${id}.json`)
+    const res = await fetch(meta.url)
+    if (!res.ok) return null
+    const data = await res.json()
+    return { ...data, timestamp: new Date(data.timestamp) }
+  } catch (err: any) {
+    if (err instanceof BlobNotFoundError || err?.name === 'BlobNotFoundError') {
+      return null
+    }
+    log.error('Failed to load conversation', err as Error)
+    return null
+  }
+}

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -30,6 +30,8 @@ export interface ChatContainerProps {
     selectedPossibility: Message
   ) => void
   onContinuePossibility?: (selectedPossibility: Message) => void
+  onPublishConversation?: () => void
+  publishDisabled?: boolean
   isLoading?: boolean
   disabled?: boolean
   className?: string

--- a/app/types/conversation.ts
+++ b/app/types/conversation.ts
@@ -1,0 +1,8 @@
+import type { Message } from './chat'
+
+export interface Conversation {
+  id: string
+  userId: string
+  messages: Message[]
+  timestamp: Date
+}


### PR DESCRIPTION
## Summary
- enable conversation publishing by storing conversations in Vercel Blob
- expose GET/POST `/api/conversations` endpoints
- show publish button in `ChatHeader`
- allow conversation pages at `/conversation/[id]`
- support initial messages in `ChatDemo`
- add fadeInOut animation
- test conversation storage service and API

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_b_686838017bdc832f902df6b8c1b907ee