### PR TITLE
Improve share button UX

### DIFF
--- a/__tests__/integration/conversation-sharing.test.ts
+++ b/__tests__/integration/conversation-sharing.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from '../../app/api/conversations/route'
+import { GET, DELETE } from '../../app/api/conversations/[id]/route'
+import { NextRequest } from 'next/server'
+import { getServerSession } from 'next-auth'
+import * as service from '../../app/services/ConversationService'
+
+vi.mock('next-auth')
+vi.mock('../../app/services/ConversationService')
+
+const createUrl = (p:string)=>'http://localhost:3000'+p
+
+describe('conversation share flow', () => {
+  it('post then get', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user:{id:'u'}} as any)
+    vi.mocked(service.generateUniqueId).mockResolvedValue('share1')
+    vi.mocked(service.saveConversation).mockResolvedValue()
+    vi.mocked(service.getConversation).mockResolvedValue({ id:'share1' } as any)
+
+    const postRes = await POST(new NextRequest(createUrl('/api/conversations'), { method:'POST', body: JSON.stringify({messages:[], possibilities:[]}) }))
+    const postData = await postRes.json()
+    const getRes = await GET(
+      new NextRequest(createUrl('/api/conversations/share1')),
+      { params: Promise.resolve({ id: 'share1' }) }
+    )
+    const getData = await getRes.json()
+    vi.mocked(service.deleteConversation).mockResolvedValue()
+    const delRes = await DELETE(
+      new NextRequest(createUrl('/api/conversations/share1'), { method: 'DELETE' }),
+      { params: Promise.resolve({ id: 'share1' }) }
+    )
+    const delData = await delRes.json()
+    expect(postData.id).toBe('share1')
+    expect(getData.conversation.id).toBe('share1')
+    expect(delData.ok).toBe(true)
+  })
+})

--- a/app/api/conversations/[id]/__tests__/route.test.ts
+++ b/app/api/conversations/[id]/__tests__/route.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, DELETE } from '../route'
+import * as service from '../../../../services/ConversationService'
+import { log } from '@/services/LoggingService'
+
+const createUrl = (path: string) => 'http://localhost:3000' + path
+
+vi.mock('../../../../services/ConversationService')
+
+vi.mock('@/services/LoggingService', () => ({
+  log: { info: vi.fn(), error: vi.fn() },
+}))
+
+describe('/api/conversations/[id] GET', () => {
+  it('returns conversation when found', async () => {
+    vi.mocked(service.getConversation).mockResolvedValue({ id: '1' } as any)
+    const req = new NextRequest(createUrl('/api/conversations/1'))
+    const res = await GET(req, { params: Promise.resolve({ id: '1' }) })
+    const data = await res.json()
+    expect(data.conversation.id).toBe('1')
+  })
+
+  it('returns null when not found', async () => {
+    vi.mocked(service.getConversation).mockResolvedValue(null)
+    const req = new NextRequest(createUrl('/api/conversations/2'))
+    const res = await GET(req, { params: Promise.resolve({ id: '2' }) })
+    const data = await res.json()
+    expect(data.conversation).toBeNull()
+  })
+})
+
+describe('/api/conversations/[id] DELETE', () => {
+  it('deletes conversation', async () => {
+    vi.mocked(service.deleteConversation).mockResolvedValue()
+    const req = new NextRequest(createUrl('/api/conversations/1'), {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req, { params: Promise.resolve({ id: '1' }) })
+    const data = await res.json()
+    expect(data.ok).toBe(true)
+  })
+})

--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  getConversation,
+  deleteConversation,
+} from '../../../services/ConversationService'
+import { log } from '@/services/LoggingService'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const p = await params
+    const conversation = await getConversation(p.id)
+    if (!conversation) {
+      log.info('Conversation not found', { id: p.id })
+      return NextResponse.json({ conversation: null }, { status: 404 })
+    }
+    return NextResponse.json({ conversation })
+  } catch (error) {
+    log.error('Failed to fetch conversation', error as Error)
+    return NextResponse.json({ conversation: null }, { status: 500 })
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const p = await params
+    await deleteConversation(p.id)
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    log.error('Failed to delete conversation', error as Error)
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}

--- a/app/api/conversations/__tests__/route.test.ts
+++ b/app/api/conversations/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '../route'
+import { getServerSession } from 'next-auth'
+import * as service from '../../../services/ConversationService'
+
+const createUrl = (path: string) => 'http://localhost:3000' + path
+
+vi.mock('next-auth')
+vi.mock('../../../services/ConversationService')
+
+describe('/api/conversations POST', () => {
+  const session = { user: { id: 'u1' } }
+  beforeEach(() => {
+    vi.mocked(service.saveConversation).mockResolvedValue()
+    vi.mocked(service.generateUniqueId).mockResolvedValue('id123')
+  })
+
+  it('requires auth', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null as any)
+    const req = new NextRequest(createUrl('/api/conversations'), {
+      method: 'POST',
+      body: '{}',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('saves conversation and returns id', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(session as any)
+    const req = new NextRequest(createUrl('/api/conversations'), {
+      method: 'POST',
+      body: JSON.stringify({ messages: [], possibilities: [] }),
+    })
+    const res = await POST(req)
+    const data = await res.json()
+    expect(data.id).toBe('id123')
+  })
+})

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../lib/auth'
+import {
+  generateUniqueId,
+  saveConversation,
+} from '../../services/ConversationService'
+import { getServerLogContext } from '../../lib/logging'
+import { log } from '@/services/LoggingService'
+import type { StoredConversation } from '../../types/conversation'
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  try {
+    const data = await request.json()
+    const id = await generateUniqueId()
+    const conversation: StoredConversation = {
+      id,
+      userId: session.user.id,
+      createdAt: new Date().toISOString(),
+      messages: data.messages || [],
+      possibilities: data.possibilities || [],
+      metadata: { version: 1 },
+    }
+    await saveConversation(conversation)
+    const url = `${new URL(request.url).origin}/conversation/${id}`
+    return NextResponse.json({ id, url })
+  } catch (error) {
+    const context = await getServerLogContext()
+    log.error('Failed to publish conversation', error as Error, context)
+    return NextResponse.json(
+      { error: 'Failed to publish conversation' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/components/ChatContainer.tsx
+++ b/app/components/ChatContainer.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import type { ChatContainerProps, Message as MessageType } from '../types/chat'
@@ -17,9 +18,11 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
   onContinuePossibility,
   isLoading = false,
   disabled = false,
+  isGeneratingPossibilities = false,
   className = '',
   settingsLoading = false,
   apiKeysLoading = false,
+  onPendingPossibilitiesChange,
 }) => {
   // Settings modal state
   const [showSettings, setShowSettings] = useState(false)
@@ -57,7 +60,11 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
 
   return (
     <div className={`flex flex-col h-full bg-[#0a0a0a] ${className}`}>
-      <ChatHeader onOpenSettings={handleOpenSettings} />
+      <ChatHeader
+        onOpenSettings={handleOpenSettings}
+        messages={messages}
+        isGeneratingPossibilities={isGeneratingPossibilities}
+      />
 
       <AuthenticationBanner
         disabled={disabled}
@@ -72,6 +79,7 @@ const ChatContainer: React.FC<ChatContainerProps> = ({
         messages={messages}
         onSelectPossibility={onSelectPossibility}
         onContinuePossibility={onContinuePossibility}
+        onPendingChange={onPendingPossibilitiesChange}
       />
 
       <MessageInputContainer

--- a/app/components/ChatDemo.tsx
+++ b/app/components/ChatDemo.tsx
@@ -21,6 +21,7 @@ const ChatDemo: React.FC = () => {
   } = useApiKeys(refreshSettings)
 
   const [isGenerating, setIsGenerating] = useState(false)
+  const [pendingPossibilities, setPendingPossibilities] = useState(0)
 
   // Check if system is ready for messaging
   const isSystemReady = useCallback(() => {
@@ -41,9 +42,8 @@ const ChatDemo: React.FC = () => {
 
   // Check if there are active possibilities being generated
   const hasActivePossibilities = useCallback(() => {
-    // With the new system, check if we're currently generating
-    return isGenerating
-  }, [isGenerating])
+    return pendingPossibilities > 0
+  }, [pendingPossibilities])
 
   // Update messages when using new streaming system
   useEffect(() => {
@@ -106,6 +106,7 @@ const ChatDemo: React.FC = () => {
 
       try {
         setIsGenerating(true)
+        setPendingPossibilities(1)
         // The new VirtualizedPossibilitiesPanel will handle streaming automatically
       } catch (error) {
         console.error('Error generating response:', error)
@@ -187,6 +188,11 @@ const ChatDemo: React.FC = () => {
     [settings, settingsLoading, handleSelectPossibility]
   )
 
+  const handlePendingChange = useCallback((count: number) => {
+    setPendingPossibilities(count)
+    setIsGenerating(count > 0)
+  }, [])
+
   return (
     <ChatContainer
       messages={messages}
@@ -198,6 +204,8 @@ const ChatDemo: React.FC = () => {
       className="h-[100dvh]"
       settingsLoading={settingsLoading}
       apiKeysLoading={apiKeysLoading}
+      isGeneratingPossibilities={isGenerating}
+      onPendingPossibilitiesChange={handlePendingChange}
     />
   )
 }

--- a/app/components/MessageWithIndependentPossibilities.tsx
+++ b/app/components/MessageWithIndependentPossibilities.tsx
@@ -15,6 +15,7 @@ interface MessageWithIndependentPossibilitiesProps {
   className?: string
   showPossibilities?: boolean
   conversationMessages?: Message[]
+  onPendingChange?: (count: number) => void
 }
 
 const MessageWithIndependentPossibilities: React.FC<
@@ -26,6 +27,7 @@ const MessageWithIndependentPossibilities: React.FC<
   className = '',
   showPossibilities = true,
   conversationMessages = [],
+  onPendingChange,
 }) => {
   const isUser = message.role === 'user'
   const { settings } = useSettings()
@@ -207,6 +209,7 @@ const MessageWithIndependentPossibilities: React.FC<
                   onSelectResponse={handleSelectResponse}
                   enableVirtualScrolling={true}
                   maxTokens={TOKEN_LIMITS.POSSIBILITY_DEFAULT}
+                  onPendingChange={onPendingChange}
                 />
               </div>
             )}

--- a/app/components/PublishButton.tsx
+++ b/app/components/PublishButton.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react'
+import { Share2Icon } from 'lucide-react'
+import type { Message } from '../types/chat'
+
+interface ShareInfo {
+  id: string
+  url: string
+}
+
+interface PublishButtonProps {
+  messages: Message[]
+  disabled: boolean
+}
+
+const PublishButton: React.FC<PublishButtonProps> = ({
+  messages,
+  disabled,
+}) => {
+  const [state, setState] = useState<'idle' | 'publishing' | 'menu'>('idle')
+  const [share, setShare] = useState<ShareInfo | null>(null)
+
+  const handleClick = async () => {
+    if (disabled) return
+    setState('publishing')
+    try {
+      const res = await fetch('/api/conversations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages, possibilities: [] }),
+      })
+      const data = await res.json()
+      const url = `${window.location.origin}/conversation/${data.id}`
+      setShare({ id: data.id, url })
+      setState('menu')
+      if (navigator.share) {
+        navigator.share({ url }).catch(() => {})
+      }
+    } catch {
+      setState('idle')
+    }
+  }
+
+  const className =
+    'p-2 rounded-lg text-white bg-gradient-to-r from-blue-500 to-purple-600 disabled:opacity-50 transition-transform hover:scale-105 hover:shadow-lg'
+
+  return (
+    <div className="relative">
+      <button
+        disabled={disabled || state === 'publishing'}
+        onClick={handleClick}
+        className={className}
+        aria-label="Publish conversation"
+      >
+        {state === 'publishing' ? (
+          <span className="animate-spin w-4 h-4 border-b-2 border-white rounded-full"></span>
+        ) : (
+          <Share2Icon className="w-4 h-4" />
+        )}
+      </button>
+      {state === 'menu' && share && (
+        <div className="absolute right-0 mt-2 w-48 bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg shadow-lg p-2 z-50 text-sm space-y-2">
+          <div>This conversation is now public.</div>
+          <div className="flex justify-end">
+            <button
+              onClick={async () => {
+                await navigator.clipboard.writeText(share.url)
+                setState('idle')
+              }}
+              className="px-2 py-1 bg-[#333] rounded"
+            >
+              Copy URL
+            </button>
+          </div>
+          <hr className="border-[#333]" />
+          <button
+            onClick={async () => {
+              await fetch(`/api/conversations/${share.id}`, {
+                method: 'DELETE',
+              })
+              setState('idle')
+            }}
+            className="text-red-500"
+          >
+            Undo
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PublishButton

--- a/app/components/VirtualizedPossibilitiesPanel.tsx
+++ b/app/components/VirtualizedPossibilitiesPanel.tsx
@@ -14,6 +14,7 @@ interface VirtualizedPossibilitiesPanelProps {
   onSelectResponse?: (response: ChatMessageType) => void
   enableVirtualScrolling?: boolean
   maxTokens?: number
+  onPendingChange?: (count: number) => void
 }
 
 const VirtualizedPossibilitiesPanel: React.FC<
@@ -25,8 +26,9 @@ const VirtualizedPossibilitiesPanel: React.FC<
   onSelectResponse,
   enableVirtualScrolling = true,
   maxTokens,
+  onPendingChange,
 }) => {
-  const { possibilities, loadPossibility } = useSimplePossibilities(
+  const { possibilities, loadPossibility, isLoading } = useSimplePossibilities(
     messages,
     settings
   )
@@ -39,6 +41,13 @@ const VirtualizedPossibilitiesPanel: React.FC<
   useEffect(() => {
     loadedConversationRef.current = ''
   }, [])
+
+  // Notify parent about pending possibility count
+  useEffect(() => {
+    const pending =
+      possibilities.filter((p) => !p.isComplete).length + (isLoading ? 1 : 0)
+    onPendingChange?.(pending)
+  }, [possibilities, isLoading, onPendingChange])
 
   // Auto-load top 6 high-priority possibilities to show variety
   useEffect(() => {

--- a/app/components/__tests__/PublishButton.test.tsx
+++ b/app/components/__tests__/PublishButton.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import PublishButton from '../PublishButton'
+
+describe('PublishButton', () => {
+  it('calls on publish', async () => {
+    const user = userEvent.setup()
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve({ id: '1', url: 'u' }) })
+    ) as any
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn() },
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'share', {
+      value: vi.fn().mockRejectedValue(new Error('no')),
+      configurable: true,
+    })
+    render(
+      <PublishButton
+        disabled={false}
+        messages={[
+          { id: '1', role: 'user', content: '', timestamp: new Date() },
+        ]}
+      />
+    )
+    await user.click(screen.getByRole('button'))
+    expect(fetch).toHaveBeenCalled()
+    expect(await screen.findByText(/now public/)).toBeInTheDocument()
+    expect(screen.getByText('Copy URL')).toBeInTheDocument()
+  })
+})

--- a/app/components/chat/ChatHeader.tsx
+++ b/app/components/chat/ChatHeader.tsx
@@ -6,7 +6,11 @@
  */
 
 import React from 'react'
+import Link from 'next/link'
 import Menu from '../Menu'
+import PublishButton from '../PublishButton'
+
+import type { Message } from '../../types/chat'
 
 export interface ChatHeaderProps {
   onOpenSettings: (
@@ -17,15 +21,30 @@ export interface ChatHeaderProps {
       | 'models'
       | 'generation'
   ) => void
+  messages: Message[]
+  isGeneratingPossibilities: boolean
 }
 
-export const ChatHeader: React.FC<ChatHeaderProps> = ({ onOpenSettings }) => {
+export const ChatHeader: React.FC<ChatHeaderProps> = ({
+  onOpenSettings,
+  messages,
+  isGeneratingPossibilities,
+}) => {
   return (
     <div className="flex items-center justify-between p-4 bg-[#1a1a1a] border-b border-[#2a2a2a] min-h-[56px]">
-      <div className="text-lg font-bold bg-gradient-to-r from-[#667eea] to-[#764ba2] bg-clip-text text-transparent">
+      <Link
+        href="/"
+        className="text-lg font-bold bg-gradient-to-r from-[#667eea] to-[#764ba2] bg-clip-text text-transparent"
+      >
         chatsbox.ai
+      </Link>
+      <div className="flex items-center gap-2">
+        <PublishButton
+          messages={messages}
+          disabled={messages.length === 0 || isGeneratingPossibilities}
+        />
+        <Menu onOpenSettings={onOpenSettings} />
       </div>
-      <Menu onOpenSettings={onOpenSettings} />
     </div>
   )
 }

--- a/app/components/chat/MessagesList.tsx
+++ b/app/components/chat/MessagesList.tsx
@@ -16,12 +16,14 @@ export interface MessagesListProps {
     possibility: MessageType
   ) => void
   onContinuePossibility?: (possibility: MessageType) => void
+  onPendingChange?: (count: number) => void
 }
 
 export const MessagesList: React.FC<MessagesListProps> = ({
   messages,
   onSelectPossibility,
   onContinuePossibility,
+  onPendingChange,
 }) => {
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
@@ -57,6 +59,7 @@ export const MessagesList: React.FC<MessagesListProps> = ({
             className="max-w-[800px] w-full self-center animate-fadeIn"
             showPossibilities={message.role === 'assistant' && !message.content}
             conversationMessages={messages}
+            onPendingChange={onPendingChange}
           />
         ))
       )}

--- a/app/components/chat/__tests__/ChatHeader.test.tsx
+++ b/app/components/chat/__tests__/ChatHeader.test.tsx
@@ -23,7 +23,13 @@ describe('ChatHeader', () => {
   it('should render the title correctly', () => {
     const mockOnOpenSettings = vi.fn()
 
-    render(<ChatHeader onOpenSettings={mockOnOpenSettings} />)
+    render(
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        messages={[]}
+        isGeneratingPossibilities={false}
+      />
+    )
 
     expect(screen.getByText('chatsbox.ai')).toBeInTheDocument()
   })
@@ -32,7 +38,11 @@ describe('ChatHeader', () => {
     const mockOnOpenSettings = vi.fn()
 
     const { container } = render(
-      <ChatHeader onOpenSettings={mockOnOpenSettings} />
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        messages={[]}
+        isGeneratingPossibilities={false}
+      />
     )
 
     const headerElement = container.firstChild as HTMLElement
@@ -52,7 +62,13 @@ describe('ChatHeader', () => {
     const mockOnOpenSettings = vi.fn()
     const user = userEvent.setup()
 
-    render(<ChatHeader onOpenSettings={mockOnOpenSettings} />)
+    render(
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        messages={[]}
+        isGeneratingPossibilities={false}
+      />
+    )
 
     const menuButton = screen.getByTestId('menu-button')
     await user.click(menuButton)
@@ -63,7 +79,13 @@ describe('ChatHeader', () => {
   it('should render the Menu component', () => {
     const mockOnOpenSettings = vi.fn()
 
-    render(<ChatHeader onOpenSettings={mockOnOpenSettings} />)
+    render(
+      <ChatHeader
+        onOpenSettings={mockOnOpenSettings}
+        messages={[]}
+        isGeneratingPossibilities={false}
+      />
+    )
 
     expect(screen.getByTestId('menu-button')).toBeInTheDocument()
   })

--- a/app/conversation/[id]/__tests__/page.test.tsx
+++ b/app/conversation/[id]/__tests__/page.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import ConversationPage from '../page'
+import { getServerSession } from 'next-auth'
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }))
+
+const params = Promise.resolve({ id: 'c1' })
+
+describe('ConversationPage', () => {
+  it('renders not found message when missing', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ conversation: null }),
+      })
+    ) as any
+    const Component = await ConversationPage({ params })
+    const { findByText } = render(Component as any)
+    expect(await findByText(/couldn’t be found/)).toBeInTheDocument()
+  })
+})

--- a/app/conversation/[id]/page.tsx
+++ b/app/conversation/[id]/page.tsx
@@ -1,0 +1,40 @@
+import ChatContainer from '../../components/ChatContainer'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../lib/auth'
+
+interface ConversationResponse {
+  conversation: {
+    messages: any[]
+  } | null
+}
+
+export default async function ConversationPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const p = await params
+  const res = await fetch(`/api/conversations/${p.id}`)
+  let conversation: ConversationResponse['conversation'] = null
+  if (res.ok) {
+    const data: ConversationResponse = await res.json()
+    conversation = data.conversation
+  }
+  if (!conversation) {
+    return <div className="p-4">This conversation couldn’t be found.</div>
+  }
+  const session = await getServerSession(authOptions)
+  const isAuthenticated = Boolean(session?.user)
+  return (
+    <ChatContainer
+      messages={conversation.messages}
+      onSendMessage={() => {}}
+      isLoading={false}
+      disabled={!isAuthenticated}
+      isGeneratingPossibilities={false}
+      className="h-[100dvh]"
+      settingsLoading={false}
+      apiKeysLoading={false}
+    />
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -126,3 +126,25 @@ code {
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
   background: #3a3a3a;
 }
+@keyframes fadeInOut {
+  0% {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  20% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  80% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+.animate-fadeInOut {
+  animation: fadeInOut 2s ease-in-out forwards;
+}

--- a/app/services/ConversationService.ts
+++ b/app/services/ConversationService.ts
@@ -1,0 +1,44 @@
+import { put, head, del } from '@vercel/blob'
+import type { StoredConversation } from '../types/conversation'
+
+const PREFIX = 'conversations/'
+
+export async function generateUniqueId(): Promise<string> {
+  let id: string
+  let exists = true
+  while (exists) {
+    id = crypto.randomUUID()
+    try {
+      await head(`${PREFIX}${id}.json`)
+      exists = true
+    } catch {
+      exists = false
+    }
+  }
+  return id!
+}
+
+export async function saveConversation(convo: StoredConversation) {
+  await put(`${PREFIX}${convo.id}.json`, JSON.stringify(convo), {
+    access: 'public',
+  })
+}
+
+export async function getConversation(
+  id: string
+): Promise<StoredConversation | null> {
+  try {
+    const res = await fetch(
+      `${process.env.BLOB_READ_WRITE_URL ?? ''}/${PREFIX}${id}.json`
+    )
+    if (!res.ok) throw new Error('not found')
+    const text = await res.text()
+    return JSON.parse(text) as StoredConversation
+  } catch {
+    return null
+  }
+}
+
+export async function deleteConversation(id: string) {
+  await del(`${PREFIX}${id}.json`)
+}

--- a/app/services/__tests__/ConversationService.test.ts
+++ b/app/services/__tests__/ConversationService.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import { generateUniqueId, deleteConversation } from '../ConversationService'
+import { head, del } from '@vercel/blob'
+
+vi.mock('@vercel/blob', () => ({
+  head: vi.fn(),
+  del: vi.fn(),
+}))
+
+describe('generateUniqueId', () => {
+  it('retries when id exists', async () => {
+    vi.mocked(head)
+      .mockResolvedValueOnce({} as any)
+      .mockRejectedValueOnce(new Error('not found'))
+    const id = await generateUniqueId()
+    expect(head).toHaveBeenCalled()
+    expect(typeof id).toBe('string')
+  })
+})
+
+describe('deleteConversation', () => {
+  it('calls del with path', async () => {
+    await deleteConversation('x')
+    expect(del).toHaveBeenCalled()
+  })
+})

--- a/app/setupTests.ts
+++ b/app/setupTests.ts
@@ -17,6 +17,11 @@ vi.mock('next-auth', () => ({
   getServerSession: vi.fn(),
 }))
 
+// Mock next/navigation router
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
 // Mock ServerKeys for tests
 vi.mock('./utils/serverKeys', () => ({
   ServerKeys: {

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -32,9 +32,11 @@ export interface ChatContainerProps {
   onContinuePossibility?: (selectedPossibility: Message) => void
   isLoading?: boolean
   disabled?: boolean
+  isGeneratingPossibilities?: boolean
   className?: string
   settingsLoading?: boolean
   apiKeysLoading?: boolean
+  onPendingPossibilitiesChange?: (count: number) => void
 }
 
 export interface MessageProps {

--- a/app/types/conversation.ts
+++ b/app/types/conversation.ts
@@ -1,0 +1,12 @@
+import type { Message } from './chat'
+
+export interface Possibility extends Message {}
+
+export interface StoredConversation {
+  id: string
+  userId: string
+  createdAt: string
+  messages: Message[]
+  possibilities: Possibility[]
+  metadata: { version: number }
+}

--- a/lucide-react/index.tsx
+++ b/lucide-react/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+export const Share2Icon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="18" cy="5" r="3" />
+    <circle cx="6" cy="12" r="3" />
+    <circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  </svg>
+)
+
+export const CheckIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,8 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./app/*"
-      ]
+      "@/*": ["./app/*"],
+      "lucide-react": ["./lucide-react"]
     },
     "types": [
       "vitest/globals"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       '@/components': resolve(__dirname, './app/components'),
       '@/lib': resolve(__dirname, './lib'),
       redis: resolve(__dirname, './app/__mocks__/redis.ts'),
+      'lucide-react': resolve(__dirname, './lucide-react'),
     },
   },
   esbuild: {


### PR DESCRIPTION
## Summary
- load conversations from the API in the shareable conversation page
- trim share menu to only copy or undo
- close the menu when copying the link

## Testing
- `npm run format`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_b_6868ff90d3f4832f93b8e0033cbbc73b