### PR TITLE
fix: add loading message to input field during initialization

### DIFF
--- a/app/components/chat/MessageInputContainer.tsx
+++ b/app/components/chat/MessageInputContainer.tsx
@@ -51,9 +51,9 @@ export const MessageInputContainer: React.FC<MessageInputContainerProps> = ({
       return 'Generating response...'
     }
 
-    // Don't show specific disabled reasons while authentication state is still loading
+    // Show loading message while settings or API keys are loading
     if (settingsLoading || apiKeysLoading) {
-      return 'Type message...'
+      return 'Loading...'
     }
 
     // Check for possibilities first (higher priority than other disabled states)

--- a/app/components/chat/__tests__/MessageInputContainer.test.tsx
+++ b/app/components/chat/__tests__/MessageInputContainer.test.tsx
@@ -63,7 +63,7 @@ describe('MessageInputContainer', () => {
       ).toBeInTheDocument()
     })
 
-    it('should show default placeholder when settingsLoading is true', () => {
+    it('should show loading placeholder when settingsLoading is true', () => {
       render(
         <MessageInputContainer
           {...defaultProps}
@@ -73,10 +73,10 @@ describe('MessageInputContainer', () => {
         />
       )
 
-      expect(screen.getByPlaceholderText('Type message...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Loading...')).toBeInTheDocument()
     })
 
-    it('should show default placeholder when apiKeysLoading is true', () => {
+    it('should show loading placeholder when apiKeysLoading is true', () => {
       render(
         <MessageInputContainer
           {...defaultProps}
@@ -86,10 +86,10 @@ describe('MessageInputContainer', () => {
         />
       )
 
-      expect(screen.getByPlaceholderText('Type message...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Loading...')).toBeInTheDocument()
     })
 
-    it('should show default placeholder when both settings and API keys are loading', () => {
+    it('should show loading placeholder when both settings and API keys are loading', () => {
       render(
         <MessageInputContainer
           {...defaultProps}
@@ -100,7 +100,7 @@ describe('MessageInputContainer', () => {
         />
       )
 
-      expect(screen.getByPlaceholderText('Type message...')).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Loading...')).toBeInTheDocument()
     })
 
     it('should show default placeholder when not disabled and not loading', () => {

--- a/devlog/2025-07-08-1546_input-loading-message.md
+++ b/devlog/2025-07-08-1546_input-loading-message.md
@@ -1,0 +1,81 @@
+# 2025-07-08-1546 - Input Loading Message Implementation
+
+## Issue Details
+**Issue Title**: Input Field Loading Message During Initialization
+**Issue Description**: The input field is disabled for a moment during UI load while settings and API keys are loading, causing confusion for users who see a disabled input with no explanation.
+**Dependencies**: MessageInputContainer component, useSettings hook, useApiKeys hook
+**Started**: 2025-07-08 15:41:00
+**Completed**: 2025-07-08 15:44:00
+
+## Summary
+Implemented a loading message in the input field placeholder to provide clear feedback to users during the unavoidable initialization delay when settings and API keys are being loaded.
+
+## Changes Made
+
+### Files Modified
+- `app/components/chat/MessageInputContainer.tsx` - Updated placeholder logic to show "Loading..." during settings/API key loading
+- `app/components/chat/__tests__/MessageInputContainer.test.tsx` - Updated 3 test cases to expect "Loading..." placeholder
+
+### Files Created
+None
+
+### Tests Added/Modified
+- `app/components/chat/__tests__/MessageInputContainer.test.tsx` - Updated tests for settingsLoading, apiKeysLoading, and combined loading states
+
+## Architecture Decisions
+
+### Design Choices
+- **Simple Loading Message**: Used "Loading..." instead of more specific messages to keep the UI clean and avoid complexity
+- **Placeholder-Based Solution**: Chose to modify the placeholder text rather than adding separate loading UI elements to maintain existing visual design
+- **Minimal Change Approach**: Only modified the placeholder logic without changing the overall component structure
+
+### Trade-offs
+- **Simplicity vs Detail**: Chose generic "Loading..." over specific messages like "Loading settings..." to avoid UI complexity
+- **Existing Tests**: Updated existing tests rather than adding new ones to maintain test coverage without over-engineering
+
+### Patterns Used
+- **Conditional Rendering**: Used existing placeholder logic pattern to handle loading states
+- **State-Based UI**: Leveraged existing loading state management from hooks
+
+## Implementation Notes
+
+### Key Algorithms/Logic
+The placeholder logic follows this priority order:
+1. "Generating response..." (highest priority - active generation)
+2. "Loading..." (settings or API keys loading)
+3. "Select a possibility to continue..." (unselected possibilities)
+4. "Type message..." (normal ready state)
+5. "Sign in to start chatting..." (unauthenticated)
+6. "Configure API keys in settings..." (no API keys)
+
+### External Dependencies
+None added - leveraged existing hooks and state management
+
+### Performance Considerations
+- No performance impact - only changed display logic
+- Loading states are already tracked by existing hooks
+
+## Testing Strategy
+- Updated existing unit tests to validate new loading message behavior
+- Maintained full test coverage for all placeholder states
+- Verified tests pass for all loading combinations (settings, API keys, both)
+
+## Known Issues/Future Work
+- Could potentially add more specific loading messages in the future
+- Could consider animated loading indicators instead of static text
+
+## Integration Points
+- Integrates with existing `useSettings` and `useApiKeys` hooks
+- Works with existing `MessageInput` component interface
+- Maintains compatibility with `ChatContainer` and `ChatDemo` components
+
+## Deployment/Configuration Changes
+None required - purely frontend UI change
+
+## Related Documentation
+- No documentation updates needed - internal UI improvement
+
+## Lessons Learned
+- The initialization delay is unavoidable due to async loading of settings and API keys
+- Simple placeholder messages can effectively communicate loading states without UI complexity
+- Existing test patterns made it easy to update validation for new behavior


### PR DESCRIPTION
- Replace generic placeholder with "Loading..." during settings/API key loading
- Update tests to validate new loading message behavior
- Improve user feedback during unavoidable initialization delay

The input field was previously disabled without explanation during the async loading of settings and API keys. This change provides clear feedback to users about what's happening during initialization.

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #80