### PR TITLE
fix: use NEXTAUTH_URL for server-side API calls in generateMetadata

### DIFF
--- a/app/conversation/[id]/page.tsx
+++ b/app/conversation/[id]/page.tsx
@@ -13,11 +13,7 @@ export async function generateMetadata({
 
   try {
     // Fetch conversation data server-side
-    const baseUrl =
-      process.env.NEXT_PUBLIC_BASE_URL ||
-      (process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
-        : 'http://localhost:3000')
+    const baseUrl = process.env.NEXTAUTH_URL || process.env.NEXT_PUBLIC_BASE_URL || 'https://chatsbox.ai'
 
     const response = await fetch(`${baseUrl}/api/conversations/${id}`, {
       next: { revalidate: 3600 }, // Cache for 1 hour


### PR DESCRIPTION
Replace complex VERCEL_URL logic with NEXTAUTH_URL which is standard and reliable for server-side fetch operations in production

🤖 Generated with [Claude Code](https://claude.ai/code)